### PR TITLE
feat: allow menu options to be hidden

### DIFF
--- a/src/components/gridForm/GridFormPopoutMenu.tsx
+++ b/src/components/gridForm/GridFormPopoutMenu.tsx
@@ -22,6 +22,7 @@ export interface MenuOption<RowType> {
   action?: (selectedRows: RowType[]) => Promise<boolean>;
   disabled?: string | boolean;
   supportsMultiEdit: boolean;
+  hidden?: boolean;
 }
 
 /**
@@ -76,6 +77,7 @@ export const GridFormPopoutMenu = <RowType extends GridBaseRow>(props: GridFormP
           item.label === MenuSeparator ? (
             <MenuDivider key={`$$divider_${index}`} />
           ) : (
+            !item.hidden &&
             <MenuItem
               key={`${item.label}`}
               onClick={() => actionClick(item)}

--- a/src/stories/components/GridReadOnly.stories.tsx
+++ b/src/stories/components/GridReadOnly.stories.tsx
@@ -86,7 +86,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
       GridPopoverMenu<ITestRow>({
         headerName: "Menu",
         cellEditorParams: {
-          options: async () => {
+          options: async (selectedItems) => {
             // Just doing a timeout here to demonstrate deferred loading
             await wait(500);
             return [
@@ -111,6 +111,11 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
               {
                 label: "Disabled item",
                 disabled: "Disabled for test",
+                supportsMultiEdit: true,
+              },
+              {
+                label: "Developer Only",
+                hidden: selectedItems.some(x=> x.position != "Developer"),
                 supportsMultiEdit: true,
               },
             ];


### PR DESCRIPTION
Sometimes context menus have options that should only show under certain conditions. Adding a little flag to the MenuOption interface means the code in the app is tidier in these scenarios.

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [x] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
