### PR TITLE
fix: export GridSubComponentTextArea from root

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,7 @@ export { GridFormTextInput } from "./src/components/gridForm/GridFormTextInput";
 
 export { TextAreaInput } from "./src/lui/TextAreaInput";
 export { TextInputFormatted } from "./src/lui/TextInputFormatted";
+export { GridSubComponentTextArea } from "./src/components/GridSubComponentTextArea"
 
 export * from "./src/utils/bearing";
 export * from "./src/utils/util";


### PR DESCRIPTION
Add export for GridSubComponentTextArea at root of package

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
