### PR TITLE
fix: pass values record back to save callback

### DIFF
--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -33,6 +33,7 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
   options:
     | SelectOption<ValueType>[]
     | ((selectedRows: RowType[]) => Promise<SelectOption<ValueType>[]> | SelectOption<ValueType>[]);
+  initialSelectedValues?: any[];
 }
 
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(props: GridFormProps<RowType>) => {
@@ -44,6 +45,10 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(prop
   const [options, setOptions] = useState<FinalSelectOption<ValueType>[]>();
   const subSelectedValues = useRef<Record<string, any>>({});
   const [selectedValues, setSelectedValues] = useState<any[]>([]);
+
+  if (formProps.initialSelectedValues) {
+    setSelectedValues(formProps.initialSelectedValues);
+  }
 
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -49,6 +49,7 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(prop
     async (selectedRows: RowType[]): Promise<boolean> => {
       const values: Record<string, any> = selectedValues.reduce((previousValue, value) => {
         previousValue[value] = subSelectedValues.current[value] ?? true;
+        return previousValue;
       }, {});
       if (formProps.onSave) {
         return await formProps.onSave({ selectedRows, values });

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -33,14 +33,14 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
   options:
     | SelectOption<ValueType>[]
     | ((selectedRows: RowType[]) => Promise<SelectOption<ValueType>[]> | SelectOption<ValueType>[]);
-  initialSelectedValues?: (props: GridFormProps<RowType>) => any[];
+  initialSelectedValues?: (selectedRows: RowType[]) => any[];
 }
 
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(props: GridFormProps<RowType>) => {
   const formProps = props.formProps as GridFormMultiSelectProps<RowType, ValueType>;
   let initValues = [];
   if (formProps.initialSelectedValues) {
-    initValues = formProps.initialSelectedValues(props);
+    initValues = formProps.initialSelectedValues(props.selectedRows);
   }
 
   const [filter, setFilter] = useState("");

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -39,7 +39,6 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(props: GridFormProps<RowType>) => {
   const formProps = props.formProps as GridFormMultiSelectProps<RowType, ValueType>;
   let initValues = [];
-  console.log("here 1 yalc");
   if (formProps.initialSelectedValues) {
     initValues = formProps.initialSelectedValues(props);
   }
@@ -50,7 +49,6 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(prop
   const [options, setOptions] = useState<FinalSelectOption<ValueType>[]>();
   const subSelectedValues = useRef<Record<string, any>>({});
   const [selectedValues, setSelectedValues] = useState<any[]>(initValues);
-
 
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -47,12 +47,11 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(prop
 
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {
-      const values: Record<string, any> = {};
-      selectedValues.forEach((value) => {
-        values[value] = subSelectedValues.current[value] ?? true;
-      });
+      const values: Record<string, any> = selectedValues.reduce((previousValue, value) => {
+        previousValue[value] = subSelectedValues.current[value] ?? true;
+      }, {});
       if (formProps.onSave) {
-        return await formProps.onSave({ selectedRows, values: selectedValues });
+        return await formProps.onSave({ selectedRows, values });
       }
       return true;
     },

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -33,22 +33,24 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
   options:
     | SelectOption<ValueType>[]
     | ((selectedRows: RowType[]) => Promise<SelectOption<ValueType>[]> | SelectOption<ValueType>[]);
-  initialSelectedValues?: any[];
+  initialSelectedValues?: (props: GridFormProps<RowType>) => any[];
 }
 
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(props: GridFormProps<RowType>) => {
   const formProps = props.formProps as GridFormMultiSelectProps<RowType, ValueType>;
+  let initValues = [];
+  console.log("here 1 yalc");
+  if (formProps.initialSelectedValues) {
+    initValues = formProps.initialSelectedValues(props);
+  }
 
   const [filter, setFilter] = useState("");
   const [filteredValues, setFilteredValues] = useState<any[]>([]);
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<FinalSelectOption<ValueType>[]>();
   const subSelectedValues = useRef<Record<string, any>>({});
-  const [selectedValues, setSelectedValues] = useState<any[]>([]);
+  const [selectedValues, setSelectedValues] = useState<any[]>(initValues);
 
-  if (formProps.initialSelectedValues) {
-    setSelectedValues(formProps.initialSelectedValues);
-  }
 
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -38,17 +38,15 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
 
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(props: GridFormProps<RowType>) => {
   const formProps = props.formProps as GridFormMultiSelectProps<RowType, ValueType>;
-  let initValues = [];
-  if (formProps.initialSelectedValues) {
-    initValues = formProps.initialSelectedValues(props.selectedRows);
-  }
 
   const [filter, setFilter] = useState("");
   const [filteredValues, setFilteredValues] = useState<any[]>([]);
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<FinalSelectOption<ValueType>[]>();
   const subSelectedValues = useRef<Record<string, any>>({});
-  const [selectedValues, setSelectedValues] = useState<any[]>(initValues);
+  const [selectedValues, setSelectedValues] = useState<any[]>(
+    formProps.initialSelectedValues ? formProps.initialSelectedValues(props.selectedRows) : [],
+  );
 
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -4,7 +4,7 @@ import { MenuItem, MenuDivider, FocusableItem, ClickEvent } from "@react-menu3";
 import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from "react";
 import { GridBaseRow } from "../Grid";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
-import { delay } from "lodash-es";
+import { delay, fromPairs } from "lodash-es";
 import { LuiCheckboxInput } from "@linzjs/lui";
 import { GenericCellEditorParams, GridFormProps } from "../GridCell";
 import { useGridPopoverHook } from "../GridPopoverHook";
@@ -44,16 +44,15 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(prop
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<FinalSelectOption<ValueType>[]>();
   const subSelectedValues = useRef<Record<string, any>>({});
-  const [selectedValues, setSelectedValues] = useState<any[]>(
+  const [selectedValues, setSelectedValues] = useState<any[]>(() =>
     formProps.initialSelectedValues ? formProps.initialSelectedValues(props.selectedRows) : [],
   );
 
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {
-      const values: Record<string, any> = selectedValues.reduce((previousValue, value) => {
-        previousValue[value] = subSelectedValues.current[value] ?? true;
-        return previousValue;
-      }, {});
+      const values: Record<string, any> = fromPairs(
+        selectedValues.map((value) => [value, subSelectedValues.current[value] ?? true]),
+      );
       if (formProps.onSave) {
         return await formProps.onSave({ selectedRows, values });
       }

--- a/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
+++ b/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
@@ -45,6 +45,12 @@ interface ITestRow {
 const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
 
+  const postionMap: Record<string, string> = {
+    "1": "One",
+    "2": "Two",
+    "3": "Three",
+  };
+
   const columnDefs = useMemo(
     () =>
       [
@@ -76,6 +82,26 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
                 subComponent: (props) => <GridSubComponentTextArea {...props} />,
               },
             ],
+            onSave: async (result: MultiSelectResult<ITestRow>) => {
+              // eslint-disable-next-line no-console
+              console.log(result);
+              await wait(1000);
+              return true;
+            },
+          },
+        }),
+        GridPopoutEditMultiSelect<ITestRow, ITestRow["position2"]>({
+          field: "position2",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Inital editor values ",
+          valueGetter: (props) => postionMap[props.data.position2],
+          cellEditorParams: {
+            multiEdit: false,
+            filtered: true,
+            filterPlaceholder: "Filter position",
+            initialSelectedValues: (selectedRows) => [selectedRows[0].position2],
+            options: Object.entries(postionMap).map(([k, v]) => ({ value: k, label: v })),
             onSave: async (result: MultiSelectResult<ITestRow>) => {
               // eslint-disable-next-line no-console
               console.log(result);

--- a/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
+++ b/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
@@ -45,74 +45,71 @@ interface ITestRow {
 const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
 
-  const postionMap: Record<string, string> = {
-    "1": "One",
-    "2": "Two",
-    "3": "Three",
-  };
-
-  const columnDefs = useMemo(
-    () =>
-      [
-        GridCell({
-          field: "id",
-          headerName: "Id",
-          initialWidth: 65,
-          maxWidth: 85,
-        }),
-        GridPopoutEditMultiSelect<ITestRow, ITestRow["position"]>({
-          field: "position",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Position",
-          cellEditorParams: {
-            multiEdit: false,
-            filtered: true,
-            filterPlaceholder: "Filter position",
-            options: [
-              { value: "a", label: "Architect" },
-              { value: "b", label: "Developer" },
-              { value: "c", label: "Product Owner" },
-              { value: "d", label: "Scrum Master" },
-              { value: "e", label: "Tester" },
-              MenuSeparator,
-              {
-                value: "f",
-                label: "Other",
-                subComponent: (props) => <GridSubComponentTextArea {...props} />,
-              },
-            ],
-            onSave: async (result: MultiSelectResult<ITestRow>) => {
-              // eslint-disable-next-line no-console
-              console.log(result);
-              await wait(1000);
-              return true;
+  const columnDefs = useMemo(() => {
+    const positionTwoMap: Record<string, string> = {
+      "1": "One",
+      "2": "Two",
+      "3": "Three",
+    };
+    return [
+      GridCell({
+        field: "id",
+        headerName: "Id",
+        initialWidth: 65,
+        maxWidth: 85,
+      }),
+      GridPopoutEditMultiSelect<ITestRow, ITestRow["position"]>({
+        field: "position",
+        initialWidth: 65,
+        maxWidth: 150,
+        headerName: "Position",
+        cellEditorParams: {
+          multiEdit: false,
+          filtered: true,
+          filterPlaceholder: "Filter position",
+          options: [
+            { value: "a", label: "Architect" },
+            { value: "b", label: "Developer" },
+            { value: "c", label: "Product Owner" },
+            { value: "d", label: "Scrum Master" },
+            { value: "e", label: "Tester" },
+            MenuSeparator,
+            {
+              value: "f",
+              label: "Other",
+              subComponent: (props) => <GridSubComponentTextArea {...props} />,
             },
+          ],
+          onSave: async (result: MultiSelectResult<ITestRow>) => {
+            // eslint-disable-next-line no-console
+            console.log(result);
+            await wait(1000);
+            return true;
           },
-        }),
-        GridPopoutEditMultiSelect<ITestRow, ITestRow["position2"]>({
-          field: "position2",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Inital editor values ",
-          valueGetter: (props) => postionMap[props.data.position2],
-          cellEditorParams: {
-            multiEdit: false,
-            filtered: true,
-            filterPlaceholder: "Filter position",
-            initialSelectedValues: (selectedRows) => [selectedRows[0].position2],
-            options: Object.entries(postionMap).map(([k, v]) => ({ value: k, label: v })),
-            onSave: async (result: MultiSelectResult<ITestRow>) => {
-              // eslint-disable-next-line no-console
-              console.log(result);
-              await wait(1000);
-              return true;
-            },
+        },
+      }),
+      GridPopoutEditMultiSelect<ITestRow, ITestRow["position2"]>({
+        field: "position2",
+        initialWidth: 65,
+        maxWidth: 150,
+        headerName: "Inital editor values ",
+        valueGetter: (props) => positionTwoMap[props.data.position2],
+        cellEditorParams: {
+          multiEdit: false,
+          filtered: true,
+          filterPlaceholder: "Filter position",
+          initialSelectedValues: (selectedRows) => [selectedRows[0].position2],
+          options: Object.entries(positionTwoMap).map(([k, v]) => ({ value: k, label: v })),
+          onSave: async (result: MultiSelectResult<ITestRow>) => {
+            // eslint-disable-next-line no-console
+            console.log(result);
+            await wait(1000);
+            return true;
           },
-        }),
-      ] as ColDef[],
-    [],
-  );
+        },
+      }),
+    ] as ColDef[];
+  }, []);
 
   const rowData = useMemo(
     () =>


### PR DESCRIPTION
DESCRIPTION of the task, STORY/TASK number and link if applicable (e.g. SURVEY-100)

* Update the the save function to return a map of values. 
* provide an optional parameter to  provide the initial selected values of the multiselect

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [x] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
