### PR TITLE
Ability to add headers to drop downs

### DIFF
--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -25,9 +25,9 @@ export const MenuSeparatorString = "_____MENU_SEPARATOR_____";
 export const MenuSeparator = Object.freeze({ value: MenuSeparatorString });
 
 export const MenuHeaderString = "_____MENU_HEADER_____";
-export const MenuHeaderItem = (title:string)=> {
-  return {label: title, value: MenuHeaderString }
-}
+export const MenuHeaderItem = (title: string) => {
+  return { label: title, value: MenuHeaderString };
+};
 
 export type SelectOption<ValueType> = ValueType | FinalSelectOption<ValueType>;
 

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -1,6 +1,6 @@
 import "../../react-menu3/styles/index.scss";
 
-import { MenuItem, MenuDivider, FocusableItem } from "@react-menu3";
+import { MenuItem, MenuDivider, FocusableItem, MenuHeader } from "@react-menu3";
 import { useCallback, useContext, useEffect, useRef, useState, KeyboardEvent } from "react";
 import { GridBaseRow } from "../Grid";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
@@ -23,6 +23,11 @@ interface FinalSelectOption<ValueType> {
 
 export const MenuSeparatorString = "_____MENU_SEPARATOR_____";
 export const MenuSeparator = Object.freeze({ value: MenuSeparatorString });
+
+export const MenuHeaderString = "_____MENU_HEADER_____";
+export const MenuHeaderItem = (title:string)=> {
+  return {label: title, value: MenuHeaderString }
+}
 
 export type SelectOption<ValueType> = ValueType | FinalSelectOption<ValueType>;
 
@@ -197,6 +202,8 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
           {options?.map((item, index) =>
             item.value === MenuSeparatorString ? (
               <MenuDivider key={`$$divider_${index}`} />
+            ) : item.value === MenuHeaderString ? (
+              <MenuHeader>{item.label}</MenuHeader>
             ) : filteredValues.includes(item.value) ? null : (
               <MenuItem
                 key={`${props.field}-${index}`}

--- a/src/stories/components/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/components/GridPopoutEditDropDown.stories.tsx
@@ -10,6 +10,7 @@ import { useCallback, useMemo, useState } from "react";
 import {
   GridFormDropDown,
   GridFormPopoutDropDownProps,
+  MenuHeaderItem,
   MenuSeparator,
   MenuSeparatorString,
 } from "@components/gridForm/GridFormDropDown";
@@ -107,6 +108,7 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
           cellEditorParams: {
             multiEdit: true,
             options: [
+              MenuHeaderItem("Something"),
               {
                 value: "1",
                 label: "One",

--- a/src/stories/components/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/components/GridPopoutEditDropDown.stories.tsx
@@ -108,7 +108,7 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
           cellEditorParams: {
             multiEdit: true,
             options: [
-              MenuHeaderItem("Something"),
+              MenuHeaderItem("Header"),
               {
                 value: "1",
                 label: "One",


### PR DESCRIPTION
A few of the existing drop down editors contain headers in the list of options. This PR allows them to be added in a similar fashion to MenuSeparators

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
