### PR TITLE
BREAKING CHANGE: refactor code to be type safe, renamed updating conext to grid updating context

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
 export * from "./src/react-menu3/index";
 export * from "./src/react-menu3/types";
 
-export * from "@contexts/GridUpdatingContext";
-export * from "@contexts/GridUpdatingContextProvider";
+export * from "./src/contexts/GridUpdatingContext";
+export * from "./src/contexts/GridUpdatingContextProvider";
 export * from "./src/contexts/GridContext";
 export * from "./src/contexts/GridContextProvider";
 

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
 export * from "./src/react-menu3/index";
 export * from "./src/react-menu3/types";
 
-export * from "./src/contexts/UpdatingContext";
-export * from "./src/contexts/UpdatingContextProvider";
+export * from "@contexts/GridUpdatingContext";
+export * from "@contexts/GridUpdatingContextProvider";
 export * from "./src/contexts/GridContext";
 export * from "./src/contexts/GridContextProvider";
 

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -12,7 +12,7 @@ import { GridContext } from "@contexts/GridContext";
 import { usePostSortRowsHook } from "./PostSortRowsHook";
 import { isNotEmpty } from "@utils/util";
 import { GridHeaderSelect } from "./gridHeader/GridHeaderSelect";
-import { UpdatingContext } from "@contexts/UpdatingContext";
+import { GridUpdatingContext } from "@contexts/GridUpdatingContext";
 
 export interface GridBaseRow {
   id: string | number;
@@ -47,7 +47,7 @@ export const Grid = (params: GridProps): JSX.Element => {
     ensureSelectedRowIsVisible,
     sizeColumnsToFit,
   } = useContext(GridContext);
-  const { checkUpdating } = useContext(UpdatingContext);
+  const { checkUpdating } = useContext(GridUpdatingContext);
 
   const [internalQuickFilter, setInternalQuickFilter] = useState("");
   const lastSelectedIds = useRef<number[]>([]);

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -14,23 +14,9 @@ import { ValueFormatterParams } from "ag-grid-community/dist/lib/entities/colDef
 import { GridPopoverContext } from "@contexts/GridPopoverContext";
 import { GridPopoverContextProvider } from "@contexts/GridPopoverContextProvider";
 
-export interface RendererProps<RowType extends GridBaseRow> extends Record<string, any> {
-  data?: RowType;
-}
-
-export interface EditorProps<RowType extends GridBaseRow> extends Record<string, any> {
-  data?: RowType;
-}
-
-export interface GenericCellEditorProps<
-  RowType extends GridBaseRow,
-  T extends RendererProps<RowType>,
-  E extends EditorProps<RowType>,
-> {
-  renderer?: (rendererProps: T) => JSX.Element;
+export interface GenericCellEditorProps<E> {
   editor?: (editorProps: E) => JSX.Element;
-  rendererParams?: T;
-  editorParams?: E;
+  editorParams?: E; // Omit<E, keyof CellParams<IFormTestRow>>
 }
 
 export const GridCellRenderer = (props: ICellRendererParams) => {
@@ -56,13 +42,21 @@ export const GridCellRenderer = (props: ICellRendererParams) => {
   );
 };
 
-/**
+// This is so that typescript retains the row type to pass to the GridCells
+export interface ColDefT<RowType extends GridBaseRow> extends ColDef {
+  _?: RowType;
+}
+
+/*
  * For editing a text area.
  */
-export const GridCell = <RowType extends GridBaseRow>(
+export const GridCell = <RowType extends GridBaseRow, Props extends { multiEdit?: boolean }>(
   props: GenericCellColDef<RowType>,
-  custom?: GenericCellEditorProps<RowType, any, any>,
-): ColDef => {
+  custom?: {
+    editor?: (editorProps: Props) => JSX.Element;
+    editorParams?: Props;
+  },
+): ColDefT<RowType> => {
   return {
     sortable: !!(props?.field || props?.valueGetter),
     resizable: true,

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -30,7 +30,7 @@ export interface GenericCellEditorProps<
   renderer?: (rendererProps: T) => JSX.Element;
   editor?: (editorProps: E) => JSX.Element;
   rendererParams?: T;
-  editorParams?: Omit<E, "value" | "data" | "field" | "selectedRows">;
+  editorParams?: E;
 }
 
 export const GridCellRenderer = (props: ICellRendererParams) => {

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, useCallback, useContext, useMemo, useState } from "react";
+import { forwardRef, useContext } from "react";
 import { GridBaseRow } from "./Grid";
 import { GridUpdatingContext } from "@contexts/GridUpdatingContext";
 import { GenericMultiEditCellClass } from "./GenericCellClass";
@@ -27,10 +27,10 @@ export interface GenericCellEditorProps<
   T extends RendererProps<RowType>,
   E extends EditorProps<RowType>,
 > {
-  renderer?: (props: T) => JSX.Element;
-  editor?: (props: E) => JSX.Element;
+  renderer?: (rendererProps: T) => JSX.Element;
+  editor?: (editorProps: E) => JSX.Element;
   rendererParams?: T;
-  editorParams?: E;
+  editorParams?: Omit<E, "value" | "data" | "field" | "selectedRows">;
 }
 
 export const GridCellRenderer = (props: ICellRendererParams) => {
@@ -87,7 +87,7 @@ export const GridCell = <RowType extends GridBaseRow>(
       originalCellRenderer: props.cellRenderer,
       ...props.cellRendererParams,
     },
-  } as ColDef;
+  };
 };
 
 export interface CellParams<RowType extends GridBaseRow> {

--- a/src/components/GridLoadableCell.tsx
+++ b/src/components/GridLoadableCell.tsx
@@ -2,6 +2,8 @@ import "./GridLoadableCell.scss";
 
 import { LuiMiniSpinner } from "@linzjs/lui";
 import clsx from "clsx";
+import { useContext } from "react";
+import { GridPopoverContext } from "@contexts/GridPopoverContext";
 
 export const GridLoadableCell = (props: {
   isLoading: boolean;
@@ -9,7 +11,8 @@ export const GridLoadableCell = (props: {
   children: JSX.Element | string;
   className?: string;
 }): JSX.Element => {
-  // console.log(`Rendering LoadableCell - loading: ${props.isLoading}`);
+  const { saving } = useContext(GridPopoverContext);
+
   if (props.isLoading) {
     return (
       <div style={{ display: "flex", alignItems: "center" }}>

--- a/src/components/GridPopoverHook.tsx
+++ b/src/components/GridPopoverHook.tsx
@@ -1,20 +1,17 @@
-import { ICellEditorParams } from "ag-grid-community";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { GridContext } from "@contexts/GridContext";
-import { GridFormProps } from "./GridCell";
 import { GridBaseRow } from "./Grid";
 import { ControlledMenu } from "@react-menu3";
+import { GridPopoverContext } from "@contexts/GridPopoverContext";
 
-export const useGridPopoverHook = <RowType extends GridBaseRow>(
-  props: GridFormProps<RowType>,
-  save?: (selectedRows: any[]) => Promise<boolean>,
-) => {
-  const { cellEditorParams, saving, updateValue } = props;
-  const { eGridCell } = cellEditorParams as ICellEditorParams;
+export interface GridPopoverHookProps<RowType> {
+  save?: (selectedRows: RowType[]) => Promise<boolean>;
+}
+
+export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopoverHookProps<RowType> = {}) => {
   const { stopEditing } = useContext(GridContext);
+  const { anchorRef, saving, updateValueRef } = useContext(GridPopoverContext);
   const saveButtonRef = useRef<HTMLButtonElement>(null);
-  const anchorRef = useRef(eGridCell);
-  anchorRef.current = eGridCell;
   const [isOpen, setOpen] = useState(false);
 
   useEffect(() => {
@@ -23,12 +20,12 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(
 
   const triggerSave = useCallback(
     async (reason?: string) => {
-      if (reason == "cancel" || !save || (await updateValue(save))) {
+      if (reason == "cancel" || !props.save || (updateValueRef.current && (await updateValueRef.current(props.save)))) {
         setOpen(false);
         stopEditing();
       }
     },
-    [save, stopEditing, updateValue],
+    [props, stopEditing, updateValueRef],
   );
 
   const popoverWrapper = useCallback(
@@ -67,7 +64,7 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(
         </>
       );
     },
-    [isOpen, saving, triggerSave],
+    [anchorRef, isOpen, saving, triggerSave],
   );
 
   return {

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -7,7 +7,7 @@ import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
 import { GridContext } from "@contexts/GridContext";
 import { delay } from "lodash-es";
 import debounce from "debounce-promise";
-import { GenericCellEditorParams, GridFormProps } from "../GridCell";
+import { CellParams } from "../GridCell";
 import { useGridPopoverHook } from "../GridPopoverHook";
 
 export interface GridPopoutEditDropDownSelectedItem<RowType, ValueType> {
@@ -31,8 +31,8 @@ export const MenuHeaderItem = (title: string) => {
 
 export type SelectOption<ValueType> = ValueType | FinalSelectOption<ValueType>;
 
-export interface GridFormPopoutDropDownProps<RowType extends GridBaseRow, ValueType>
-  extends GenericCellEditorParams<RowType> {
+export interface GridFormPopoutDropDownProps<RowType extends GridBaseRow, ValueType> {
+  multiEdit?: boolean;
   filtered?: "local" | "reload";
   filterPlaceholder?: string;
   onSelectedItem?: (props: GridPopoutEditDropDownSelectedItem<RowType, ValueType>) => Promise<void>;
@@ -43,10 +43,9 @@ export interface GridFormPopoutDropDownProps<RowType extends GridBaseRow, ValueT
   optionsRequestCancel?: () => void;
 }
 
-export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: GridFormProps<RowType>) => {
-  const { popoverWrapper } = useGridPopoverHook(props);
-  const formProps = props.formProps as GridFormPopoutDropDownProps<RowType, ValueType>;
-
+export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
+  props: GridFormPopoutDropDownProps<RowType, ValueType> & CellParams<RowType>,
+) => {
   const { updatingCells, stopEditing } = useContext(GridContext);
 
   const [filter, setFilter] = useState("");
@@ -60,8 +59,8 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
       return await updatingCells({ selectedRows: props.selectedRows, field }, async (selectedRows) => {
         const hasChanged = selectedRows.some((row) => row[field as keyof RowType] !== value);
         if (hasChanged) {
-          if (formProps.onSelectedItem) {
-            await formProps.onSelectedItem({ selectedRows, value });
+          if (props.onSelectedItem) {
+            await props.onSelectedItem({ selectedRows, value });
           } else {
             selectedRows.forEach((row) => (row[field as keyof RowType] = value));
           }
@@ -69,27 +68,27 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
         return true;
       });
     },
-    [formProps, props.field, props.selectedRows, updatingCells],
+    [props, updatingCells],
   );
 
   const selectFilterHandler = useCallback(
     async (value: string): Promise<boolean> => {
       const field = props.field;
       return await updatingCells({ selectedRows: props.selectedRows, field }, async (selectedRows) => {
-        if (formProps.onSelectFilter) {
-          await formProps.onSelectFilter({ selectedRows, value });
+        if (props.onSelectFilter) {
+          await props.onSelectFilter({ selectedRows, value });
         }
         return true;
       });
     },
-    [formProps, props.field, props.selectedRows, updatingCells],
+    [props, updatingCells],
   );
 
   // Load up options list if it's async function
   useEffect(() => {
     if (options || optionsInitialising.current) return;
     optionsInitialising.current = true;
-    let optionsConf = formProps.options ?? [];
+    let optionsConf = props.options ?? [];
 
     (async () => {
       if (typeof optionsConf == "function") {
@@ -103,7 +102,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
         return item;
       }) as any as FinalSelectOption<ValueType>[];
 
-      if (formProps.filtered) {
+      if (props.filtered) {
         // This is needed otherwise when filter input is rendered and sets autofocus
         // the mouse up of the double click edit triggers the cell to cancel editing
         delay(() => setOptions(optionsList), 100);
@@ -112,11 +111,11 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
       }
       optionsInitialising.current = false;
     })();
-  }, [filter, options, formProps.filtered, formProps.options, props.selectedRows]);
+  }, [filter, options, props]);
 
   // Local filtering
   useEffect(() => {
-    if (formProps.filtered == "local") {
+    if (props.filtered == "local") {
       if (options == null) return;
       setFilteredValues(
         options
@@ -131,7 +130,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
           .filter((r) => r !== undefined),
       );
     }
-  }, [formProps.filtered, filter, options]);
+  }, [props.filtered, filter, options]);
 
   const researchOnFilterChange = debounce(
     useCallback(() => {
@@ -144,12 +143,12 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
 
   // Reload filtering
   useEffect(() => {
-    if (previousFilter.current != filter && formProps.filtered == "reload") {
+    if (previousFilter.current != filter && props.filtered == "reload") {
       previousFilter.current = filter;
-      formProps.optionsRequestCancel && formProps.optionsRequestCancel();
+      props.optionsRequestCancel && props.optionsRequestCancel();
       researchOnFilterChange().then();
     }
-  }, [filter, formProps, props, researchOnFilterChange]);
+  }, [filter, props, researchOnFilterChange]);
 
   const onFilterKeyDown = useCallback(
     async (e: KeyboardEvent) => {
@@ -159,7 +158,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
         if (activeOptions.length == 1) {
           await selectItemHandler(activeOptions[0].value);
           stopEditing();
-        } else if (formProps.onSelectFilter) {
+        } else if (props.onSelectFilter) {
           await selectFilterHandler(filter);
           stopEditing();
         } else {
@@ -168,12 +167,13 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
         }
       }
     },
-    [filteredValues, options, selectItemHandler, selectFilterHandler, stopEditing, filter, formProps],
+    [filteredValues, options, selectItemHandler, selectFilterHandler, stopEditing, filter, props],
   );
 
+  const { popoverWrapper } = useGridPopoverHook();
   return popoverWrapper(
     <>
-      {formProps.filtered && (
+      {props.filtered && (
         <>
           <FocusableItem className={"filter-item"}>
             {({ ref }: any) => (
@@ -184,7 +184,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(props: 
                   style={{ border: "0px" }}
                   ref={ref}
                   type="text"
-                  placeholder={formProps.filterPlaceholder ?? "Placeholder"}
+                  placeholder={props.filterPlaceholder ?? "Placeholder"}
                   data-testid={"filteredMenu-free-text-input"}
                   defaultValue={filter}
                   onChange={(e) => setFilter(e.target.value.toLowerCase())}

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -41,6 +41,7 @@ export interface GridFormPopoutDropDownProps<RowType extends GridBaseRow, ValueT
     | SelectOption<ValueType>[]
     | ((selectedRows: RowType[], filter?: string) => Promise<SelectOption<ValueType>[]> | SelectOption<ValueType>[]);
   optionsRequestCancel?: () => void;
+  maxRows?: number;
 }
 
 export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
@@ -96,12 +97,12 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
         optionsConf = await optionsConf(props.selectedRows, filter);
       }
 
-      const optionsList = optionsConf?.map((item) => {
+      const optionsList = (optionsConf?.map((item) => {
         if (item == null || typeof item == "string" || typeof item == "number") {
           item = { value: item as ValueType, label: item, disabled: false } as FinalSelectOption<ValueType>;
         }
         return item;
-      }) as any as FinalSelectOption<ValueType>[];
+      }) as any) as FinalSelectOption<ValueType>[];
 
       if (props.filtered) {
         // This is needed otherwise when filter input is rendered and sets autofocus
@@ -171,6 +172,8 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
     [filteredValues, options, selectItemHandler, selectFilterHandler, stopEditing, filter, props],
   );
 
+  const maxRowsStyles =
+    props.maxRows !== undefined ? { maxHeight: 62 + 34 * props.maxRows, overFlowY: "auto" } : undefined;
   const { popoverWrapper } = useGridPopoverHook();
   return popoverWrapper(
     <>
@@ -198,7 +201,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
         </>
       )}
       <ComponentLoadingWrapper loading={!options}>
-        <>
+        <div style={maxRowsStyles}>
           {options && options.length == filteredValues?.length && <MenuItem>[Empty]</MenuItem>}
           {options?.map((item, index) =>
             item.value === MenuSeparatorString ? (
@@ -217,7 +220,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
               </MenuItem>
             ),
           )}
-        </>
+        </div>
       </ComponentLoadingWrapper>
     </>,
   );

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -44,8 +44,9 @@ export interface GridFormPopoutDropDownProps<RowType extends GridBaseRow, ValueT
 }
 
 export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
-  props: GridFormPopoutDropDownProps<RowType, ValueType> & CellParams<RowType>,
+  _props: GridFormPopoutDropDownProps<RowType, ValueType>,
 ) => {
+  const props = _props as GridFormPopoutDropDownProps<RowType, ValueType> & CellParams<RowType>;
   const { updatingCells, stopEditing } = useContext(GridContext);
 
   const [filter, setFilter] = useState("");

--- a/src/components/gridForm/GridFormEditBearing.tsx
+++ b/src/components/gridForm/GridFormEditBearing.tsx
@@ -14,9 +14,8 @@ export interface GridFormEditBearingProps<RowType extends GridBaseRow> {
   onSave?: (selectedRows: RowType[], value: number | null) => Promise<boolean>;
 }
 
-export const GridFormEditBearing = <RowType extends GridBaseRow>(
-  props: GridFormEditBearingProps<RowType> & CellParams<RowType>,
-) => {
+export const GridFormEditBearing = <RowType extends GridBaseRow>(_props: GridFormEditBearingProps<RowType>) => {
+  const props = _props as GridFormEditBearingProps<RowType> & CellParams<RowType>;
   const [value, setValue] = useState<string>(`${props.value ?? ""}`);
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {

--- a/src/components/gridForm/GridFormMessage.tsx
+++ b/src/components/gridForm/GridFormMessage.tsx
@@ -1,28 +1,25 @@
 import { useEffect, useState } from "react";
-import { GenericCellEditorParams, GridFormProps } from "../GridCell";
-import { ICellEditorParams } from "ag-grid-community";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
 import { GridBaseRow } from "../Grid";
 import { useGridPopoverHook } from "../GridPopoverHook";
+import { CellParams } from "@components/GridCell";
 
-export interface GridFormMessageProps<RowType extends GridBaseRow> extends GenericCellEditorParams<RowType> {
-  message: (
-    selectedRows: RowType[],
-    cellEditorParams: ICellEditorParams,
-  ) => Promise<string | JSX.Element> | string | JSX.Element;
+export interface GridFormMessageProps<RowType extends GridBaseRow> {
+  multiEdit?: boolean;
+  message: (cellParams: CellParams<RowType>) => Promise<string | JSX.Element> | string | JSX.Element;
 }
 
-export const GridFormMessage = <RowType extends GridBaseRow>(props: GridFormProps<RowType>) => {
-  const formProps = props.formProps as GridFormMessageProps<RowType>;
-
+export const GridFormMessage = <RowType extends GridBaseRow>(
+  props: GridFormMessageProps<RowType> & CellParams<RowType>,
+) => {
   const [message, setMessage] = useState<string | JSX.Element | null>(null);
-  const { popoverWrapper } = useGridPopoverHook(props);
+  const { popoverWrapper } = useGridPopoverHook();
 
   useEffect(() => {
     (async () => {
-      setMessage(await formProps.message(props.selectedRows, props.cellEditorParams));
+      setMessage(await props.message(props));
     })().then();
-  }, [formProps, props.selectedRows, props]);
+  }, [props]);
 
   return popoverWrapper(
     <ComponentLoadingWrapper loading={message === null}>

--- a/src/components/gridForm/GridFormMessage.tsx
+++ b/src/components/gridForm/GridFormMessage.tsx
@@ -9,9 +9,8 @@ export interface GridFormMessageProps<RowType extends GridBaseRow> {
   message: (cellParams: CellParams<RowType>) => Promise<string | JSX.Element> | string | JSX.Element;
 }
 
-export const GridFormMessage = <RowType extends GridBaseRow>(
-  props: GridFormMessageProps<RowType> & CellParams<RowType>,
-) => {
+export const GridFormMessage = <RowType extends GridBaseRow>(_props: GridFormMessageProps<RowType>) => {
+  const props = _props as GridFormMessageProps<RowType> & CellParams<RowType>;
   const [message, setMessage] = useState<string | JSX.Element | null>(null);
   const { popoverWrapper } = useGridPopoverHook();
 

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -35,15 +35,16 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
 }
 
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(
-  props: GridFormMultiSelectProps<RowType, ValueType> & CellParams<RowType>,
+  props: GridFormMultiSelectProps<RowType, ValueType>,
 ) => {
+  const { selectedRows } = props as unknown as CellParams<RowType>;
   const [filter, setFilter] = useState("");
   const [filteredValues, setFilteredValues] = useState<any[]>([]);
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<MultiFinalSelectOption<ValueType>[]>();
   const subSelectedValues = useRef<Record<string, any>>({});
   const [selectedValues, setSelectedValues] = useState<any[]>(() =>
-    props.initialSelectedValues ? props.initialSelectedValues(props.selectedRows) : [],
+    props.initialSelectedValues ? props.initialSelectedValues(selectedRows) : [],
   );
 
   const save = useCallback(
@@ -68,7 +69,7 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(
 
     (async () => {
       if (typeof optionsConf == "function") {
-        optionsConf = await optionsConf(props.selectedRows);
+        optionsConf = await optionsConf(selectedRows);
       }
 
       const optionsList = optionsConf?.map((item) => {
@@ -87,7 +88,7 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(
       }
       optionsInitialising.current = false;
     })();
-  }, [props.filtered, props.options, options, props.selectedRows]);
+  }, [props.filtered, props.options, options, selectedRows]);
 
   useEffect(() => {
     if (!props.filtered || options == null) return;

--- a/src/components/gridForm/GridFormPopoutMenu.tsx
+++ b/src/components/gridForm/GridFormPopoutMenu.tsx
@@ -30,9 +30,8 @@ export interface MenuOption<RowType> {
  * NOTE: If the popout menu doesn't appear on single click when also selecting row it's because
  * you need a useMemo around your columnDefs
  */
-export const GridFormPopoutMenu = <RowType extends GridBaseRow>(
-  props: GridFormPopoutMenuProps<RowType> & CellParams<RowType>,
-) => {
+export const GridFormPopoutMenu = <RowType extends GridBaseRow>(_props: GridFormPopoutMenuProps<RowType>) => {
+  const props = _props as GridFormPopoutMenuProps<RowType> & CellParams<RowType>;
   const { updatingCells } = useContext(GridContext);
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<MenuOption<RowType>[]>();

--- a/src/components/gridForm/GridFormPopoutMenu.tsx
+++ b/src/components/gridForm/GridFormPopoutMenu.tsx
@@ -3,10 +3,10 @@ import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { GridContext } from "@contexts/GridContext";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
 import { MenuDivider, MenuItem } from "@react-menu3";
-import { GenericCellEditorParams, GridFormProps } from "../GridCell";
 import { useGridPopoverHook } from "../GridPopoverHook";
+import { CellParams } from "@components/GridCell";
 
-export interface GridFormPopoutMenuProps<RowType extends GridBaseRow> extends GenericCellEditorParams<RowType> {
+export interface GridFormPopoutMenuProps<RowType extends GridBaseRow> {
   options: (selectedRows: RowType[]) => Promise<MenuOption<RowType>[]>;
 }
 
@@ -29,9 +29,9 @@ export interface MenuOption<RowType> {
  * NOTE: If the popout menu doesn't appear on single click when also selecting row it's because
  * you need a useMemo around your columnDefs
  */
-export const GridFormPopoutMenu = <RowType extends GridBaseRow>(props: GridFormProps<RowType>) => {
-  const formProps = props.formProps as GridFormPopoutMenuProps<RowType>;
-
+export const GridFormPopoutMenu = <RowType extends GridBaseRow>(
+  props: GridFormPopoutMenuProps<RowType> & CellParams<RowType>,
+) => {
   const { updatingCells } = useContext(GridContext);
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<MenuOption<RowType>[]>();
@@ -40,7 +40,7 @@ export const GridFormPopoutMenu = <RowType extends GridBaseRow>(props: GridFormP
   useEffect(() => {
     if (options || optionsInitialising.current) return;
     optionsInitialising.current = true;
-    const optionsConf = formProps.options ?? [];
+    const optionsConf = props.options ?? [];
 
     (async () => {
       if (typeof optionsConf == "function") {
@@ -51,7 +51,7 @@ export const GridFormPopoutMenu = <RowType extends GridBaseRow>(props: GridFormP
 
       optionsInitialising.current = false;
     })();
-  }, [options, formProps.options, props.selectedRows]);
+  }, [options, props.options, props.selectedRows]);
 
   const actionClick = useCallback(
     async (menuOption: MenuOption<any>) => {
@@ -69,7 +69,7 @@ export const GridFormPopoutMenu = <RowType extends GridBaseRow>(props: GridFormP
     return menuOption.label === PopoutMenuSeparator || selectedRowCount === 1 || menuOption.supportsMultiEdit;
   });
 
-  const { popoverWrapper } = useGridPopoverHook(props);
+  const { popoverWrapper } = useGridPopoverHook();
   return popoverWrapper(
     <ComponentLoadingWrapper loading={!filteredOptions}>
       <div className={"Grid-popoverContainerList"}>

--- a/src/components/gridForm/GridFormPopoutMenu.tsx
+++ b/src/components/gridForm/GridFormPopoutMenu.tsx
@@ -7,6 +7,7 @@ import { useGridPopoverHook } from "../GridPopoverHook";
 import { CellParams } from "@components/GridCell";
 
 export interface GridFormPopoutMenuProps<RowType extends GridBaseRow> {
+  multiEdit?: boolean;
   options: (selectedRows: RowType[]) => Promise<MenuOption<RowType>[]>;
 }
 

--- a/src/components/gridForm/GridFormTextArea.tsx
+++ b/src/components/gridForm/GridFormTextArea.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "react";
-import { GenericCellEditorParams, GridFormProps } from "../GridCell";
 import { TextAreaInput } from "../../lui/TextAreaInput";
 import { useGridPopoverHook } from "../GridPopoverHook";
 import { GridBaseRow } from "../Grid";
+import { CellParams } from "@components/GridCell";
 
-export interface GridFormTextAreaProps<RowType extends GridBaseRow> extends GenericCellEditorParams<RowType> {
+export interface GridFormTextAreaProps<RowType extends GridBaseRow> {
+  multiEdit?: boolean;
   placeholder?: string;
   required?: boolean;
   maxlength?: number;
@@ -13,22 +14,23 @@ export interface GridFormTextAreaProps<RowType extends GridBaseRow> extends Gene
   onSave?: (selectedRows: RowType[], value: string) => Promise<boolean>;
 }
 
-export const GridFormTextArea = <RowType extends GridBaseRow>(props: GridFormProps<RowType>) => {
-  const formProps = props.formProps as GridFormTextAreaProps<RowType>;
+export const GridFormTextArea = <RowType extends GridBaseRow>(
+  props: GridFormTextAreaProps<RowType> & CellParams<RowType>,
+) => {
   const [value, setValue] = useState(props.value ?? "");
 
   const invalid = useCallback(() => {
-    if (formProps.required && value.length == 0) {
+    if (props.required && value.length == 0) {
       return `Some text is required`;
     }
-    if (formProps.maxlength && value.length > formProps.maxlength) {
-      return `Text must be no longer than ${formProps.maxlength} characters`;
+    if (props.maxlength && value.length > props.maxlength) {
+      return `Text must be no longer than ${props.maxlength} characters`;
     }
-    if (formProps.validate) {
-      return formProps.validate(value);
+    if (props.validate) {
+      return props.validate(value);
     }
     return null;
-  }, [formProps, value]);
+  }, [props, value]);
 
   const save = useCallback(
     async (selectedRows: any[]): Promise<boolean> => {
@@ -36,8 +38,8 @@ export const GridFormTextArea = <RowType extends GridBaseRow>(props: GridFormPro
 
       if (props.value === (value ?? "")) return true;
 
-      if (formProps.onSave) {
-        return await formProps.onSave(selectedRows, value);
+      if (props.onSave) {
+        return await props.onSave(selectedRows, value);
       }
 
       const field = props.field;
@@ -48,17 +50,16 @@ export const GridFormTextArea = <RowType extends GridBaseRow>(props: GridFormPro
       selectedRows.forEach((row) => (row[field] = value));
       return true;
     },
-    [formProps, invalid, props.field, props.value, value],
+    [props, invalid, value],
   );
-  const { popoverWrapper } = useGridPopoverHook(props, save);
-
+  const { popoverWrapper } = useGridPopoverHook({ save });
   return popoverWrapper(
-    <div style={{ display: "flex", flexDirection: "row", width: formProps.width ?? 240 }} className={"FormTest"}>
+    <div style={{ display: "flex", flexDirection: "row", width: props.width ?? 240 }} className={"FormTest"}>
       <TextAreaInput
         value={value}
         onChange={(e) => setValue(e.target.value)}
         error={invalid()}
-        inputProps={{ placeholder: formProps.placeholder }}
+        inputProps={{ placeholder: props.placeholder }}
       />
     </div>,
   );

--- a/src/components/gridForm/GridFormTextArea.tsx
+++ b/src/components/gridForm/GridFormTextArea.tsx
@@ -14,9 +14,8 @@ export interface GridFormTextAreaProps<RowType extends GridBaseRow> {
   onSave?: (selectedRows: RowType[], value: string) => Promise<boolean>;
 }
 
-export const GridFormTextArea = <RowType extends GridBaseRow>(
-  props: GridFormTextAreaProps<RowType> & CellParams<RowType>,
-) => {
+export const GridFormTextArea = <RowType extends GridBaseRow>(_props: GridFormTextAreaProps<RowType>) => {
+  const props = _props as GridFormTextAreaProps<RowType> & CellParams<RowType>;
   const [value, setValue] = useState(props.value ?? "");
 
   const invalid = useCallback(() => {

--- a/src/components/gridForm/GridFormTextInput.tsx
+++ b/src/components/gridForm/GridFormTextInput.tsx
@@ -16,9 +16,8 @@ export interface GridFormTextInputProps<RowType extends GridBaseRow> {
   onSave?: (selectedRows: RowType[], value: string) => Promise<boolean>;
 }
 
-export const GridFormTextInput = <RowType extends GridBaseRow>(
-  props: GridFormTextInputProps<RowType> & CellParams<RowType>,
-) => {
+export const GridFormTextInput = <RowType extends GridBaseRow>(_props: GridFormTextInputProps<RowType>) => {
+  const props = _props as GridFormTextInputProps<RowType> & CellParams<RowType>;
   const initValue = props.value == null ? "" : `${props.value}`;
   const [value, setValue] = useState(initValue);
 

--- a/src/components/gridPopoverEdit/GridPopoutEditMultiSelect.ts
+++ b/src/components/gridPopoverEdit/GridPopoutEditMultiSelect.ts
@@ -1,12 +1,12 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormMultiSelect, GridFormMultiSelectProps } from "../gridForm/GridFormMultiSelect";
-import { ColDef } from "ag-grid-community";
+import { GenericCellColDef } from "@components/gridRender/GridRenderGenericCell";
 
 export const GridPopoutEditMultiSelect = <RowType extends GridBaseRow, ValueType>(
-  colDef: ColDef,
-  props: { editorParams: GridFormMultiSelectProps<RowType, ValueType> },
+  colDef: GenericCellColDef<RowType>,
+  props: GenericCellEditorProps<RowType, any, GridFormMultiSelectProps<RowType, ValueType>>,
 ) =>
   GridCell<RowType>(
     {

--- a/src/components/gridPopoverEdit/GridPopoutEditMultiSelect.ts
+++ b/src/components/gridPopoverEdit/GridPopoutEditMultiSelect.ts
@@ -1,14 +1,14 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormMultiSelect, GridFormMultiSelectProps } from "../gridForm/GridFormMultiSelect";
 import { GenericCellColDef } from "@components/gridRender/GridRenderGenericCell";
 
 export const GridPopoutEditMultiSelect = <RowType extends GridBaseRow, ValueType>(
   colDef: GenericCellColDef<RowType>,
-  props: GenericCellEditorProps<RowType, any, GridFormMultiSelectProps<RowType, ValueType>>,
-) =>
-  GridCell<RowType>(
+  props: GenericCellEditorProps<GridFormMultiSelectProps<RowType, ValueType>>,
+): ColDefT<RowType> =>
+  GridCell(
     {
       initialWidth: 65,
       maxWidth: 150,

--- a/src/components/gridPopoverEdit/GridPopoutEditMultiSelect.ts
+++ b/src/components/gridPopoverEdit/GridPopoutEditMultiSelect.ts
@@ -1,21 +1,22 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 import { GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormMultiSelect, GridFormMultiSelectProps } from "../gridForm/GridFormMultiSelect";
+import { ColDef } from "ag-grid-community";
 
 export const GridPopoutEditMultiSelect = <RowType extends GridBaseRow, ValueType>(
-  colDef: GenericCellColDef<RowType, GridFormMultiSelectProps<RowType, ValueType>>,
+  colDef: ColDef,
+  props: { editorParams: GridFormMultiSelectProps<RowType, ValueType> },
 ) =>
-  GridCell<RowType, GridFormMultiSelectProps<RowType, ValueType>>({
-    initialWidth: 65,
-    maxWidth: 150,
-    cellClass: colDef.cellEditor?.multiEdit ? GenericMultiEditCellClass : undefined,
-    ...colDef,
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        ...colDef.cellEditorParams,
-        form: GridFormMultiSelect,
-      },
-    }),
-  });
+  GridCell<RowType>(
+    {
+      initialWidth: 65,
+      maxWidth: 150,
+      cellClass: colDef.cellEditor?.multiEdit ? GenericMultiEditCellClass : undefined,
+      ...colDef,
+    },
+    {
+      editor: GridFormMultiSelect,
+      ...props,
+    },
+  );

--- a/src/components/gridPopoverEdit/GridPopoverEditBearing.ts
+++ b/src/components/gridPopoverEdit/GridPopoverEditBearing.ts
@@ -1,20 +1,20 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
 import { bearingCorrectionValueFormatter, bearingValueFormatter } from "@utils/bearing";
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridFormEditBearing, GridFormEditBearingProps } from "../gridForm/GridFormEditBearing";
 import { GridBaseRow } from "../Grid";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverEditBearingLike = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: { editorParams: GridFormEditBearingProps<RowType> },
+  props: GenericCellEditorProps<RowType, any, GridFormEditBearingProps<RowType>>,
 ) => {
   return GridCell(
     {
       initialWidth: 65,
       maxWidth: 150,
       valueFormatter: bearingValueFormatter,
-      cellClass: props.editorParams.multiEdit ? GenericMultiEditCellClass : undefined,
+      cellClass: props.editorParams?.multiEdit ? GenericMultiEditCellClass : undefined,
       ...colDef,
     },
     {
@@ -26,14 +26,14 @@ export const GridPopoverEditBearingLike = <RowType extends GridBaseRow>(
 
 export const GridPopoverEditBearing = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: { editorParams: GridFormEditBearingProps<RowType> },
+  props: GenericCellEditorProps<RowType, any, GridFormEditBearingProps<RowType>>,
 ) => {
   return GridPopoverEditBearingLike(
     { valueFormatter: bearingValueFormatter, ...colDef },
     {
       editorParams: {
         placeHolder: "Enter bearing correction",
-        multiEdit: !!props.editorParams.multiEdit,
+        multiEdit: !!props.editorParams?.multiEdit,
         range: (value: number | null) => {
           if (value === null) return "Bearing correction is required";
           if (value >= 360) return "Bearing correction must be less than 360 degrees";
@@ -48,14 +48,14 @@ export const GridPopoverEditBearing = <RowType extends GridBaseRow>(
 
 export const GridPopoverEditBearingCorrection = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: { editorParams: GridFormEditBearingProps<RowType> },
+  props: GenericCellEditorProps<RowType, any, GridFormEditBearingProps<RowType>>,
 ) => {
   return GridPopoverEditBearingLike(
     { valueFormatter: bearingCorrectionValueFormatter, ...colDef },
     {
       editorParams: {
         placeHolder: "Enter bearing correction",
-        multiEdit: !!props.editorParams.multiEdit,
+        multiEdit: !!props.editorParams?.multiEdit,
         range: (value: number | null) => {
           if (value === null) return "Bearing is required";
           if (value >= 360) return "Bearing must be less than 360 degrees";

--- a/src/components/gridPopoverEdit/GridPopoverEditBearing.ts
+++ b/src/components/gridPopoverEdit/GridPopoverEditBearing.ts
@@ -1,61 +1,69 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 import { bearingCorrectionValueFormatter, bearingValueFormatter } from "@utils/bearing";
 import { GridCell } from "../GridCell";
 import { GridFormEditBearing, GridFormEditBearingProps } from "../gridForm/GridFormEditBearing";
 import { GridBaseRow } from "../Grid";
+import { ColDef } from "ag-grid-community";
 
 export const GridPopoverEditBearingLike = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormEditBearingProps<RowType>>,
-) =>
-  GridCell<RowType, GridFormEditBearingProps<RowType>>({
-    initialWidth: 65,
-    maxWidth: 150,
-    valueFormatter: bearingValueFormatter,
-    cellClass: colDef.cellEditorParams?.multiEdit ? GenericMultiEditCellClass : undefined,
-    ...colDef,
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        ...colDef.cellEditorParams,
-        form: GridFormEditBearing,
-      },
-    }),
-  });
+  colDef: ColDef,
+  props: { editorParams: GridFormEditBearingProps<RowType> },
+) => {
+  return GridCell(
+    {
+      initialWidth: 65,
+      maxWidth: 150,
+      valueFormatter: bearingValueFormatter,
+      cellClass: props.editorParams.multiEdit ? GenericMultiEditCellClass : undefined,
+      ...colDef,
+    },
+    {
+      editor: GridFormEditBearing,
+      editorParams: props.editorParams,
+    },
+  );
+};
 
 export const GridPopoverEditBearing = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormEditBearingProps<RowType>>,
+  colDef: ColDef,
+  props: { editorParams: GridFormEditBearingProps<RowType> },
 ) => {
-  const init = GridPopoverEditBearingLike(colDef);
-  return {
-    ...init,
-    valueFormatter: bearingValueFormatter,
-    cellEditorParams: {
-      range: (value: number | null) => {
-        if (value === null) return "Bearing is required";
-        if (value >= 360) return "Bearing must be less than 360 degrees";
-        if (value < 0) return "Bearing must not be negative";
-        return null;
+  return GridPopoverEditBearingLike(
+    { valueFormatter: bearingValueFormatter, ...colDef },
+    {
+      editorParams: {
+        placeHolder: "Enter bearing correction",
+        multiEdit: !!props.editorParams.multiEdit,
+        range: (value: number | null) => {
+          if (value === null) return "Bearing correction is required";
+          if (value >= 360) return "Bearing correction must be less than 360 degrees";
+          if (value < 0) return "Bearing correction must not be negative";
+          return null;
+        },
+        ...props.editorParams,
       },
-      ...init.cellEditorParams,
     },
-  };
+  );
 };
 
 export const GridPopoverEditBearingCorrection = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormEditBearingProps<RowType>>,
+  colDef: ColDef,
+  props: { editorParams: GridFormEditBearingProps<RowType> },
 ) => {
-  const init = GridPopoverEditBearingLike(colDef);
-  return {
-    ...init,
-    valueFormatter: bearingCorrectionValueFormatter,
-    cellEditorParams: {
-      range: (value: number | null) => {
-        if (value === null) return "Bearing is required";
-        if (value >= 360) return "Bearing must be less than 360 degrees";
-        if (value <= -180) return "Bearing must be greater then -180 degrees";
-        return null;
+  return GridPopoverEditBearingLike(
+    { valueFormatter: bearingCorrectionValueFormatter, ...colDef },
+    {
+      editorParams: {
+        placeHolder: "Enter bearing correction",
+        multiEdit: !!props.editorParams.multiEdit,
+        range: (value: number | null) => {
+          if (value === null) return "Bearing is required";
+          if (value >= 360) return "Bearing must be less than 360 degrees";
+          if (value <= -180) return "Bearing must be greater then -180 degrees";
+          return null;
+        },
+        ...props.editorParams,
       },
-      ...init.cellEditorParams,
     },
-  };
+  );
 };

--- a/src/components/gridPopoverEdit/GridPopoverEditBearing.ts
+++ b/src/components/gridPopoverEdit/GridPopoverEditBearing.ts
@@ -1,14 +1,14 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
 import { bearingCorrectionValueFormatter, bearingValueFormatter } from "@utils/bearing";
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridFormEditBearing, GridFormEditBearingProps } from "../gridForm/GridFormEditBearing";
 import { GridBaseRow } from "../Grid";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverEditBearingLike = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: GenericCellEditorProps<RowType, any, GridFormEditBearingProps<RowType>>,
-) => {
+  props: GenericCellEditorProps<GridFormEditBearingProps<RowType>>,
+): ColDefT<RowType> => {
   return GridCell(
     {
       initialWidth: 65,
@@ -19,15 +19,15 @@ export const GridPopoverEditBearingLike = <RowType extends GridBaseRow>(
     },
     {
       editor: GridFormEditBearing,
-      editorParams: props.editorParams,
+      ...props,
     },
   );
 };
 
 export const GridPopoverEditBearing = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: GenericCellEditorProps<RowType, any, GridFormEditBearingProps<RowType>>,
-) => {
+  props: GenericCellEditorProps<GridFormEditBearingProps<RowType>>,
+): ColDefT<RowType> => {
   return GridPopoverEditBearingLike(
     { valueFormatter: bearingValueFormatter, ...colDef },
     {
@@ -48,8 +48,8 @@ export const GridPopoverEditBearing = <RowType extends GridBaseRow>(
 
 export const GridPopoverEditBearingCorrection = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: GenericCellEditorProps<RowType, any, GridFormEditBearingProps<RowType>>,
-) => {
+  props: GenericCellEditorProps<GridFormEditBearingProps<RowType>>,
+): ColDefT<RowType> => {
   return GridPopoverEditBearingLike(
     { valueFormatter: bearingCorrectionValueFormatter, ...colDef },
     {

--- a/src/components/gridPopoverEdit/GridPopoverEditDropDown.ts
+++ b/src/components/gridPopoverEdit/GridPopoverEditDropDown.ts
@@ -1,14 +1,14 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormDropDown, GridFormPopoutDropDownProps } from "../gridForm/GridFormDropDown";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverEditDropDown = <RowType extends GridBaseRow, ValueType>(
   colDef: ColDef,
-  props: GenericCellEditorProps<RowType, any, GridFormPopoutDropDownProps<RowType, ValueType>>,
-) =>
-  GridCell<RowType>(
+  props: GenericCellEditorProps<GridFormPopoutDropDownProps<RowType, ValueType>>,
+): ColDefT<RowType> =>
+  GridCell(
     {
       initialWidth: 65,
       maxWidth: 150,

--- a/src/components/gridPopoverEdit/GridPopoverEditDropDown.ts
+++ b/src/components/gridPopoverEdit/GridPopoverEditDropDown.ts
@@ -1,21 +1,22 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 import { GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormDropDown, GridFormPopoutDropDownProps } from "../gridForm/GridFormDropDown";
+import { ColDef } from "ag-grid-community";
 
 export const GridPopoverEditDropDown = <RowType extends GridBaseRow, ValueType>(
-  colDef: GenericCellColDef<RowType, GridFormPopoutDropDownProps<RowType, ValueType>>,
+  colDef: ColDef,
+  props: { editorParams: GridFormPopoutDropDownProps<RowType, ValueType> },
 ) =>
-  GridCell<RowType, GridFormPopoutDropDownProps<RowType, ValueType>>({
-    initialWidth: 65,
-    maxWidth: 150,
-    cellClass: colDef.cellEditor?.multiEdit ? GenericMultiEditCellClass : undefined,
-    ...colDef,
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        ...colDef.cellEditorParams,
-        form: GridFormDropDown,
-      },
-    }),
-  });
+  GridCell<RowType>(
+    {
+      initialWidth: 65,
+      maxWidth: 150,
+      cellClass: props.editorParams.multiEdit ? GenericMultiEditCellClass : undefined,
+      ...colDef,
+    },
+    {
+      editor: GridFormDropDown,
+      ...props,
+    },
+  );

--- a/src/components/gridPopoverEdit/GridPopoverEditDropDown.ts
+++ b/src/components/gridPopoverEdit/GridPopoverEditDropDown.ts
@@ -1,18 +1,18 @@
 import { GenericMultiEditCellClass } from "../GenericCellClass";
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormDropDown, GridFormPopoutDropDownProps } from "../gridForm/GridFormDropDown";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverEditDropDown = <RowType extends GridBaseRow, ValueType>(
   colDef: ColDef,
-  props: { editorParams: GridFormPopoutDropDownProps<RowType, ValueType> },
+  props: GenericCellEditorProps<RowType, any, GridFormPopoutDropDownProps<RowType, ValueType>>,
 ) =>
   GridCell<RowType>(
     {
       initialWidth: 65,
       maxWidth: 150,
-      cellClass: props.editorParams.multiEdit ? GenericMultiEditCellClass : undefined,
+      cellClass: props.editorParams?.multiEdit ? GenericMultiEditCellClass : undefined,
       ...colDef,
     },
     {

--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -7,29 +7,28 @@ import { GridBaseRow } from "../Grid";
 import { GridCell } from "../GridCell";
 import { GridFormPopoutMenu, GridFormPopoutMenuProps } from "../gridForm/GridFormPopoutMenu";
 import { GridRenderPopoutMenuCell } from "../gridRender/GridRenderPopoutMenuCell";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 
 /**
  * Popout burger menu
  */
 export const GridPopoverMenu = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormPopoutMenuProps<RowType>>,
+  colDef: ColDef,
+  props: { editorParams: GridFormPopoutMenuProps<RowType> },
 ): ColDef =>
-  GridCell<RowType, GridFormPopoutMenuProps<RowType>>({
-    maxWidth: 64,
-    editable: colDef.editable != null ? colDef.editable : true,
-    cellRenderer: GridRenderPopoutMenuCell,
-    cellClass: colDef?.cellEditorParams?.multiEdit !== false ? GenericMultiEditCellClass : undefined,
-    ...colDef,
-    cellRendererParams: {
-      // Menus open on single click, this parameter is picked up in Grid.tsx
-      singleClickEdit: true,
-    },
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        multiEdit: true,
-        ...colDef.cellEditorParams,
-        form: GridFormPopoutMenu,
+  GridCell<RowType>(
+    {
+      maxWidth: 64,
+      editable: colDef.editable != null ? colDef.editable : true,
+      cellRenderer: GridRenderPopoutMenuCell,
+      cellClass: colDef?.cellEditorParams?.multiEdit !== false ? GenericMultiEditCellClass : undefined,
+      ...colDef,
+      cellRendererParams: {
+        // Menus open on single click, this parameter is picked up in Grid.tsx
+        singleClickEdit: true,
       },
-    }),
-  });
+    },
+    {
+      editor: GridFormPopoutMenu,
+      ...props,
+    },
+  );

--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -4,7 +4,7 @@ import "../../react-menu3/styles/index.scss";
 import { ColDef } from "ag-grid-community";
 import { GenericMultiEditCellClass } from "../GenericCellClass";
 import { GridBaseRow } from "../Grid";
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridFormPopoutMenu, GridFormPopoutMenuProps } from "../gridForm/GridFormPopoutMenu";
 import { GridRenderPopoutMenuCell } from "../gridRender/GridRenderPopoutMenuCell";
 
@@ -13,7 +13,7 @@ import { GridRenderPopoutMenuCell } from "../gridRender/GridRenderPopoutMenuCell
  */
 export const GridPopoverMenu = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: { editorParams: GridFormPopoutMenuProps<RowType> },
+  props: GenericCellEditorProps<RowType, any, GridFormPopoutMenuProps<RowType>>,
 ): ColDef =>
   GridCell<RowType>(
     {

--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -4,7 +4,7 @@ import "../../react-menu3/styles/index.scss";
 import { ColDef } from "ag-grid-community";
 import { GenericMultiEditCellClass } from "../GenericCellClass";
 import { GridBaseRow } from "../Grid";
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridFormPopoutMenu, GridFormPopoutMenuProps } from "../gridForm/GridFormPopoutMenu";
 import { GridRenderPopoutMenuCell } from "../gridRender/GridRenderPopoutMenuCell";
 
@@ -13,9 +13,9 @@ import { GridRenderPopoutMenuCell } from "../gridRender/GridRenderPopoutMenuCell
  */
 export const GridPopoverMenu = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: GenericCellEditorProps<RowType, any, GridFormPopoutMenuProps<RowType>>,
-): ColDef =>
-  GridCell<RowType>(
+  props: GenericCellEditorProps<GridFormPopoutMenuProps<RowType>>,
+): ColDefT<RowType> =>
+  GridCell<RowType, GridFormPopoutMenuProps<RowType>>(
     {
       maxWidth: 64,
       editable: colDef.editable != null ? colDef.editable : true,

--- a/src/components/gridPopoverEdit/GridPopoverMessage.ts
+++ b/src/components/gridPopoverEdit/GridPopoverMessage.ts
@@ -1,18 +1,19 @@
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridFormMessage, GridFormMessageProps } from "../gridForm/GridFormMessage";
 import { GridBaseRow } from "../Grid";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverMessage = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: GenericCellEditorProps<RowType, any, GridFormMessageProps<RowType>>,
-) => {
-  return GridCell<RowType>(
+  props: GenericCellEditorProps<GridFormMessageProps<RowType>>,
+): ColDefT<RowType> => {
+  return GridCell(
     {
       maxWidth: 140,
       ...colDef,
-      cellRendererParams: colDef.cellRendererParams ?? {
+      cellRendererParams: {
         singleClickEdit: true,
+        ...colDef.cellRendererParams,
       },
     },
     {

--- a/src/components/gridPopoverEdit/GridPopoverMessage.ts
+++ b/src/components/gridPopoverEdit/GridPopoverMessage.ts
@@ -1,11 +1,11 @@
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridFormMessage, GridFormMessageProps } from "../gridForm/GridFormMessage";
 import { GridBaseRow } from "../Grid";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverMessage = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  props: { editorParams: GridFormMessageProps<RowType> },
+  props: GenericCellEditorProps<RowType, any, GridFormMessageProps<RowType>>,
 ) => {
   return GridCell<RowType>(
     {

--- a/src/components/gridPopoverEdit/GridPopoverMessage.ts
+++ b/src/components/gridPopoverEdit/GridPopoverMessage.ts
@@ -1,22 +1,23 @@
 import { GridCell } from "../GridCell";
 import { GridFormMessage, GridFormMessageProps } from "../gridForm/GridFormMessage";
 import { GridBaseRow } from "../Grid";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
+import { ColDef } from "ag-grid-community";
 
 export const GridPopoverMessage = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormMessageProps<RowType>>,
+  colDef: ColDef,
+  props: { editorParams: GridFormMessageProps<RowType> },
 ) => {
-  return GridCell<RowType, GridFormMessageProps<RowType>>({
-    maxWidth: 140,
-    ...colDef,
-    cellRendererParams: colDef.cellRendererParams ?? {
-      singleClickEdit: true,
-    },
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        ...colDef.cellEditorParams,
-        form: GridFormMessage,
+  return GridCell<RowType>(
+    {
+      maxWidth: 140,
+      ...colDef,
+      cellRendererParams: colDef.cellRendererParams ?? {
+        singleClickEdit: true,
       },
-    }),
-  });
+    },
+    {
+      editor: GridFormMessage,
+      ...props,
+    },
+  );
 };

--- a/src/components/gridPopoverEdit/GridPopoverTextArea.ts
+++ b/src/components/gridPopoverEdit/GridPopoverTextArea.ts
@@ -1,17 +1,16 @@
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormTextArea, GridFormTextAreaProps } from "../gridForm/GridFormTextArea";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverTextArea = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  params: GenericCellEditorProps<RowType, any, GridFormTextAreaProps<RowType>>,
-) => {
-  return GridCell<RowType>(
+  params: GenericCellEditorProps<GridFormTextAreaProps<RowType>>,
+): ColDefT<RowType> =>
+  GridCell(
     {
       maxWidth: 260,
       ...colDef,
     },
     { editor: GridFormTextArea, ...params },
   );
-};

--- a/src/components/gridPopoverEdit/GridPopoverTextArea.ts
+++ b/src/components/gridPopoverEdit/GridPopoverTextArea.ts
@@ -1,20 +1,17 @@
 import { GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 import { GridFormTextArea, GridFormTextAreaProps } from "../gridForm/GridFormTextArea";
+import { ColDef } from "ag-grid-community";
 
 export const GridPopoverTextArea = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormTextAreaProps<RowType>>,
+  colDef: ColDef,
+  params: { editorParams: GridFormTextAreaProps<RowType> },
 ) => {
-  return GridCell<RowType, GridFormTextAreaProps<RowType>>({
-    maxWidth: 260,
-    ...colDef,
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        width: 260,
-        ...colDef.cellEditorParams,
-        form: GridFormTextArea,
-      },
-    }),
-  });
+  return GridCell<RowType>(
+    {
+      maxWidth: 260,
+      ...colDef,
+    },
+    { editor: GridFormTextArea, ...params },
+  );
 };

--- a/src/components/gridPopoverEdit/GridPopoverTextArea.ts
+++ b/src/components/gridPopoverEdit/GridPopoverTextArea.ts
@@ -1,11 +1,11 @@
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormTextArea, GridFormTextAreaProps } from "../gridForm/GridFormTextArea";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverTextArea = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  params: { editorParams: GridFormTextAreaProps<RowType> },
+  params: GenericCellEditorProps<RowType, any, GridFormTextAreaProps<RowType>>,
 ) => {
   return GridCell<RowType>(
     {

--- a/src/components/gridPopoverEdit/GridPopoverTextInput.ts
+++ b/src/components/gridPopoverEdit/GridPopoverTextInput.ts
@@ -2,19 +2,20 @@ import { GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 import { GridFormTextInput, GridFormTextInputProps } from "../gridForm/GridFormTextInput";
+import { ColDef } from "ag-grid-community";
 
 export const GridPopoverTextInput = <RowType extends GridBaseRow>(
-  colDef: GenericCellColDef<RowType, GridFormTextInputProps<RowType>>,
+  colDef: ColDef,
+  params: { editorParams: GridFormTextInputProps<RowType> },
 ) => {
-  return GridCell<RowType, GridFormTextInputProps<RowType>>({
-    maxWidth: 140,
-    ...colDef,
-    ...(colDef?.cellEditorParams && {
-      cellEditorParams: {
-        width: 240,
-        ...colDef.cellEditorParams,
-        form: GridFormTextInput,
-      },
-    }),
-  });
+  return GridCell<RowType>(
+    {
+      maxWidth: 140,
+      ...colDef,
+    },
+    {
+      editor: GridFormTextInput,
+      ...params,
+    },
+  );
 };

--- a/src/components/gridPopoverEdit/GridPopoverTextInput.ts
+++ b/src/components/gridPopoverEdit/GridPopoverTextInput.ts
@@ -1,13 +1,13 @@
-import { GenericCellEditorProps, GridCell } from "../GridCell";
+import { ColDefT, GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 import { GridFormTextInput, GridFormTextInputProps } from "../gridForm/GridFormTextInput";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverTextInput = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  params: GenericCellEditorProps<RowType, any, GridFormTextInputProps<RowType>>,
-) => {
-  return GridCell<RowType>(
+  params: GenericCellEditorProps<GridFormTextInputProps<RowType>>,
+): ColDefT<RowType> => {
+  return GridCell(
     {
       maxWidth: 140,
       ...colDef,

--- a/src/components/gridPopoverEdit/GridPopoverTextInput.ts
+++ b/src/components/gridPopoverEdit/GridPopoverTextInput.ts
@@ -1,12 +1,11 @@
-import { GridCell } from "../GridCell";
+import { GenericCellEditorProps, GridCell } from "../GridCell";
 import { GridBaseRow } from "../Grid";
-import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
 import { GridFormTextInput, GridFormTextInputProps } from "../gridForm/GridFormTextInput";
 import { ColDef } from "ag-grid-community";
 
 export const GridPopoverTextInput = <RowType extends GridBaseRow>(
   colDef: ColDef,
-  params: { editorParams: GridFormTextInputProps<RowType> },
+  params: GenericCellEditorProps<RowType, any, GridFormTextInputProps<RowType>>,
 ) => {
   return GridCell<RowType>(
     {

--- a/src/components/gridRender/GridRenderGenericCell.tsx
+++ b/src/components/gridRender/GridRenderGenericCell.tsx
@@ -1,21 +1,19 @@
 import "./GridRenderGenericCell.scss";
 
 import { useContext } from "react";
-import { UpdatingContext } from "@contexts/UpdatingContext";
+import { GridUpdatingContext } from "@contexts/GridUpdatingContext";
 import { GridLoadableCell } from "../GridLoadableCell";
 import { GridIcon } from "../GridIcon";
 import { ColDef, ICellRendererParams } from "ag-grid-community";
 import { ValueFormatterParams } from "ag-grid-community/dist/lib/entities/colDef";
-import { GenericCellEditorParams } from "../GridCell";
 import { GridBaseRow } from "../Grid";
 
 export interface RowICellRendererParams<RowType extends GridBaseRow> extends ICellRendererParams {
   data: RowType;
 }
 
-export interface GenericCellColDef<RowType extends GridBaseRow, FormProps extends Record<string, any>> extends ColDef {
+export interface GenericCellColDef<RowType extends GridBaseRow> extends ColDef {
   cellRendererParams?: GenericCellRendererParams<RowType>;
-  cellEditorParams?: GenericCellEditorParams<RowType> & FormProps;
 }
 
 export interface GenericCellRendererParams<RowType extends GridBaseRow> {
@@ -25,7 +23,7 @@ export interface GenericCellRendererParams<RowType extends GridBaseRow> {
 }
 
 export const GridRendererGenericCell = <RowType extends GridBaseRow>(props: ICellRendererParams): JSX.Element => {
-  const { checkUpdating } = useContext(UpdatingContext);
+  const { checkUpdating } = useContext(GridUpdatingContext);
 
   const colDef = props.colDef as ColDef;
   const cellRendererParams = colDef.cellRendererParams as GenericCellRendererParams<RowType> | undefined;

--- a/src/components/gridRender/GridRenderPopoutMenuCell.tsx
+++ b/src/components/gridRender/GridRenderPopoutMenuCell.tsx
@@ -1,12 +1,12 @@
 import { useContext } from "react";
 import { ColDef, ICellRendererParams } from "ag-grid-community";
-import { UpdatingContext } from "@contexts/UpdatingContext";
+import { GridUpdatingContext } from "@contexts/GridUpdatingContext";
 import { GridLoadableCell } from "../GridLoadableCell";
 import { LuiIcon } from "@linzjs/lui";
 import { Column } from "ag-grid-community/dist/lib/entities/column";
 
 export const GridRenderPopoutMenuCell = (props: ICellRendererParams) => {
-  const { checkUpdating } = useContext(UpdatingContext);
+  const { checkUpdating } = useContext(GridUpdatingContext);
   const isLoading = checkUpdating(props.colDef?.field ?? "", props.data.id);
   const editable = props.colDef?.editable;
   const disabled = !(typeof editable === "function"

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -3,7 +3,7 @@ import { GridApi, RowNode } from "ag-grid-community";
 import { GridContext } from "./GridContext";
 import { delay, difference, isEmpty, last, sortBy } from "lodash-es";
 import { isNotEmpty } from "@utils/util";
-import { UpdatingContext } from "./UpdatingContext";
+import { GridUpdatingContext } from "./GridUpdatingContext";
 import { GridBaseRow } from "@components/Grid";
 
 interface GridContextProps {
@@ -16,7 +16,7 @@ interface GridContextProps {
  * Also, make sure the provider is created in a separate component, otherwise it won't be found.
  */
 export const GridContextProvider = (props: GridContextProps): ReactElement => {
-  const { modifyUpdating } = useContext(UpdatingContext);
+  const { modifyUpdating } = useContext(GridUpdatingContext);
   const gridApiRef = useRef<GridApi>();
   const idsBeforeUpdate = useRef<number[]>([]);
 

--- a/src/contexts/GridPopoverContext.tsx
+++ b/src/contexts/GridPopoverContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, RefObject } from "react";
+import { ICellEditorParams } from "ag-grid-community";
+
+export interface PropsType {
+  value: any;
+  data: any;
+  field: string;
+  selectedRows: any[];
+}
+
+export type GridPopoverContextType = {
+  anchorRef: RefObject<Element>;
+  updateValueRef: RefObject<(saveFn: (selectedRows: any[]) => Promise<boolean>) => Promise<boolean>>;
+  saving: boolean;
+  setSaving: (saving: boolean) => void;
+  setProps: (props: ICellEditorParams, multiEdit: boolean) => void;
+  propsRef: RefObject<PropsType>;
+};
+
+export const GridPopoverContext = createContext<GridPopoverContextType>({
+  anchorRef: { current: null },
+  updateValueRef: {
+    current: async () => {
+      console.error("Missing GridPopoverContext updateValueRef");
+      return false;
+    },
+  },
+  saving: false,
+  setSaving: () => {},
+  setProps: () => {},
+  propsRef: { current: null },
+});

--- a/src/contexts/GridPopoverContextProvider.tsx
+++ b/src/contexts/GridPopoverContextProvider.tsx
@@ -1,0 +1,53 @@
+import { ReactNode, RefObject, useContext, useRef, useState } from "react";
+import { GridPopoverContext, PropsType } from "./GridPopoverContext";
+import { ICellEditorParams } from "ag-grid-community";
+import { GridBaseRow } from "@components/Grid";
+import { GridContext } from "@contexts/GridContext";
+
+interface GridPopoverContextProps {
+  children: ReactNode;
+}
+
+export const GridPopoverContextProvider = (props: GridPopoverContextProps) => {
+  const { getSelectedRows, updatingCells } = useContext(GridContext);
+  const anchorRef = useRef<Element>();
+  const propsRef = useRef<PropsType>({} as PropsType);
+  const updateValueRef = useRef<(saveFn: (selectedRows: any[]) => Promise<boolean>) => Promise<boolean>>(async () => {
+    console.error("updateValueRef.current is not set");
+    return false;
+  });
+
+  const [saving, setSaving] = useState(false);
+
+  const setProps = (props: ICellEditorParams, multiEdit: boolean) => {
+    const selectedRows = multiEdit ? getSelectedRows<GridBaseRow>() : [props.data];
+    const field = props.colDef?.field ?? "";
+
+    anchorRef.current = props.eGridCell;
+    propsRef.current = {
+      value: props.value,
+      data: props.data,
+      field,
+      selectedRows,
+    };
+
+    updateValueRef.current = async (saveFn: (selectedRows: any[]) => Promise<boolean>): Promise<boolean> => {
+      return !saving && (await updatingCells({ selectedRows, field }, saveFn, setSaving));
+    };
+  };
+
+  return (
+    <GridPopoverContext.Provider
+      value={{
+        anchorRef: anchorRef as any as RefObject<Element>,
+        saving,
+        setSaving,
+        updateValueRef,
+        propsRef,
+        setProps,
+      }}
+    >
+      {props.children}
+    </GridPopoverContext.Provider>
+  );
+};

--- a/src/contexts/GridUpdatingContext.tsx
+++ b/src/contexts/GridUpdatingContext.tsx
@@ -1,11 +1,11 @@
 import { createContext } from "react";
 
-export type UpdatingContextType = {
+export type GridUpdatingContextType = {
   checkUpdating: (fields: string | string[], id: number | string) => boolean;
   modifyUpdating: (field: string, ids: (number | string)[], fn: () => void | Promise<void>) => Promise<void>;
 };
 
-export const UpdatingContext = createContext<UpdatingContextType>({
+export const GridUpdatingContext = createContext<GridUpdatingContextType>({
   checkUpdating: () => {
     console.error("Missing UpdatingContext");
     return false;

--- a/src/contexts/GridUpdatingContextProvider.tsx
+++ b/src/contexts/GridUpdatingContextProvider.tsx
@@ -1,23 +1,23 @@
 import { ReactNode, useRef } from "react";
 import { castArray, flatten, remove } from "lodash-es";
-import { UpdatingContext } from "./UpdatingContext";
+import { GridUpdatingContext } from "./GridUpdatingContext";
 
 interface UpdatingContextProviderProps {
   children: ReactNode;
 }
 
-export type UpdatingContextStatus = Record<string, (number | string)[] | undefined>;
+export type GridUpdatingContextStatus = Record<string, (number | string)[] | undefined>;
 
 type FieldName = string;
 type IdList = (number | string)[];
 type UpdatingBlock = Record<FieldName, IdList[]>;
 
-export const UpdatingContextProvider = (props: UpdatingContextProviderProps) => {
+export const GridUpdatingContextProvider = (props: UpdatingContextProviderProps) => {
   const updatingBlocks = useRef<UpdatingBlock>({});
-  const updating = useRef<UpdatingContextStatus>({});
+  const updating = useRef<GridUpdatingContextStatus>({});
 
   const resetUpdating = () => {
-    const mergedUpdatingBlocks: UpdatingContextStatus = {};
+    const mergedUpdatingBlocks: GridUpdatingContextStatus = {};
     for (const key in updatingBlocks.current) {
       mergedUpdatingBlocks[key] = flatten(updatingBlocks.current[key]);
     }
@@ -38,6 +38,8 @@ export const UpdatingContextProvider = (props: UpdatingContextProviderProps) => 
     castArray(fields).some((f) => updating.current[f]?.includes(id));
 
   return (
-    <UpdatingContext.Provider value={{ modifyUpdating, checkUpdating }}>{props.children}</UpdatingContext.Provider>
+    <GridUpdatingContext.Provider value={{ modifyUpdating, checkUpdating }}>
+      {props.children}
+    </GridUpdatingContext.Provider>
   );
 };

--- a/src/stories/components/FormTest.tsx
+++ b/src/stories/components/FormTest.tsx
@@ -3,7 +3,7 @@ import "./FormTest.scss";
 import { useCallback, useState } from "react";
 import { LuiTextInput } from "@linzjs/lui";
 import { wait } from "@utils/util";
-import { GridFormProps } from "@components/GridCell";
+import { CellParams } from "@components/GridCell";
 import { useGridPopoverHook } from "@components/GridPopoverHook";
 import { GridBaseRow } from "@components/Grid";
 
@@ -16,7 +16,7 @@ export interface IFormTestRow {
   distance: number | null;
 }
 
-export const FormTest = <RowType extends GridBaseRow>(props: GridFormProps<RowType>): JSX.Element => {
+export const FormTest = <RowType extends GridBaseRow>(props: CellParams<RowType>): JSX.Element => {
   const [v1, v2, ...v3] = props.value.split(" ");
 
   const [nameType, setNameType] = useState(v1);
@@ -34,7 +34,7 @@ export const FormTest = <RowType extends GridBaseRow>(props: GridFormProps<RowTy
     // Close form
     return true;
   }, [nameType, numba, plan, props.selectedRows]);
-  const { popoverWrapper } = useGridPopoverHook(props, save);
+  const { popoverWrapper } = useGridPopoverHook({ save });
 
   return popoverWrapper(
     <div style={{ display: "flex", flexDirection: "row" }} className={"FormTest Grid-popoverContainer"}>

--- a/src/stories/components/FormTest.tsx
+++ b/src/stories/components/FormTest.tsx
@@ -16,7 +16,8 @@ export interface IFormTestRow {
   distance: number | null;
 }
 
-export const FormTest = <RowType extends GridBaseRow>(props: CellParams<RowType>): JSX.Element => {
+export const FormTest = <RowType extends GridBaseRow>(_props: any): JSX.Element => {
+  const props = _props as CellParams<RowType>;
   const [v1, v2, ...v3] = props.value.split(" ");
 
   const [nameType, setNameType] = useState(v1);

--- a/src/stories/components/GridPopoutBearing.stories.tsx
+++ b/src/stories/components/GridPopoutBearing.stories.tsx
@@ -55,7 +55,6 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
           field: "bearing1",
           headerName: "Bearing GCE",
           cellRendererParams: {
-            // FIXME
             warning: (props: any) => props.data.id == 1002 && "Testers are testing",
             info: (props: any) => props.data.id == 1001 && "Developers are developing",
           },

--- a/src/stories/components/GridPopoutBearing.stories.tsx
+++ b/src/stories/components/GridPopoutBearing.stories.tsx
@@ -4,7 +4,7 @@ import "../../lui-overrides.scss";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
 import { useMemo, useState } from "react";
-import { UpdatingContextProvider } from "@contexts/UpdatingContextProvider";
+import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { GridCell } from "@components/GridCell";
@@ -24,11 +24,11 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ width: 1200, height: 400, display: "flex" }}>
-        <UpdatingContextProvider>
+        <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
           </GridContextProvider>
-        </UpdatingContextProvider>
+        </GridUpdatingContextProvider>
       </div>
     ),
   ],
@@ -50,31 +50,37 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridPopoverEditBearing<ITestRow>({
-        field: "bearing1",
-        headerName: "Bearing GCE",
-        cellRendererParams: {
-          warning: (props) => props.data.id == 1002 && "Testers are testing",
-          info: (props) => props.data.id == 1001 && "Developers are developing",
-        },
-        cellEditorParams: {
-          multiEdit: false,
-          placeHolder: "Enter Bearing",
-        },
-      }),
-      GridPopoverEditBearingCorrection<ITestRow>({
-        field: "bearingCorrection",
-        headerName: "Bearing Correction",
-        cellEditorParams: {
-          multiEdit: true,
-          placeHolder: "Enter Bearing Correction",
-          onSave: async (selectedRows: ITestRow[], value: ITestRow["bearingCorrection"]) => {
-            await wait(1000);
-            selectedRows.forEach((row) => (row["bearingCorrection"] = value));
-            return true;
+      GridPopoverEditBearing<ITestRow>(
+        {
+          field: "bearing1",
+          headerName: "Bearing GCE",
+          cellRendererParams: {
+            // FIXME
+            warning: (props: any) => props.data.id == 1002 && "Testers are testing",
+            info: (props: any) => props.data.id == 1001 && "Developers are developing",
           },
         },
-      }),
+        {
+          editorParams: {
+            multiEdit: false,
+          },
+        },
+      ),
+      GridPopoverEditBearingCorrection<ITestRow>(
+        {
+          field: "bearingCorrection",
+          headerName: "Bearing Correction",
+        },
+        {
+          editorParams: {
+            onSave: async (selectedRows, value: ITestRow["bearingCorrection"]) => {
+              await wait(1000);
+              selectedRows.forEach((row) => (row["bearingCorrection"] = value));
+              return true;
+            },
+          },
+        },
+      ),
     ],
     [],
   );

--- a/src/stories/components/GridPopoutBearing.stories.tsx
+++ b/src/stories/components/GridPopoutBearing.stories.tsx
@@ -7,7 +7,7 @@ import { useMemo, useState } from "react";
 import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
-import { GridCell } from "@components/GridCell";
+import { ColDefT, GridCell } from "@components/GridCell";
 import {
   GridPopoverEditBearing,
   GridPopoverEditBearingCorrection,
@@ -42,7 +42,7 @@ interface ITestRow {
 
 const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
-  const columnDefs = useMemo(
+  const columnDefs: ColDefT<ITestRow>[] = useMemo(
     () => [
       GridCell({
         field: "id",
@@ -50,7 +50,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridPopoverEditBearing<ITestRow>(
+      GridPopoverEditBearing(
         {
           field: "bearing1",
           headerName: "Bearing GCE",
@@ -65,7 +65,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
           },
         },
       ),
-      GridPopoverEditBearingCorrection<ITestRow>(
+      GridPopoverEditBearingCorrection(
         {
           field: "bearingCorrection",
           headerName: "Bearing Correction",

--- a/src/stories/components/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/components/GridPopoutEditDropDown.stories.tsx
@@ -8,9 +8,8 @@ import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useCallback, useMemo, useState } from "react";
 import { MenuHeaderItem, MenuSeparator, MenuSeparatorString } from "@components/gridForm/GridFormDropDown";
-import { ColDef } from "ag-grid-community";
 import { wait } from "@utils/util";
-import { GridCell } from "@components/GridCell";
+import { ColDefT, GridCell } from "@components/GridCell";
 import { GridPopoverEditDropDown } from "@components/gridPopoverEdit/GridPopoverEditDropDown";
 
 export default {
@@ -75,154 +74,153 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
     [],
   );
 
-  const columnDefs = useMemo(
-    () =>
-      [
-        GridCell({
-          field: "id",
-          headerName: "Id",
+  const columnDefs: ColDefT<ITestRow>[] = useMemo(
+    () => [
+      GridCell({
+        field: "id",
+        headerName: "Id",
+        initialWidth: 65,
+        maxWidth: 85,
+      }),
+      GridPopoverEditDropDown(
+        {
+          field: "position",
           initialWidth: 65,
-          maxWidth: 85,
-        }),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position"]>(
-          {
-            field: "position",
-            initialWidth: 65,
-            maxWidth: 150,
-            headerName: "Position",
+          maxWidth: 150,
+          headerName: "Position",
+        },
+        {
+          editorParams: {
+            options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
+            multiEdit: false,
           },
-          {
-            editorParams: {
-              options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
-              multiEdit: false,
-            },
-          },
-        ),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position2"]>(
-          {
-            field: "position2",
-            maxWidth: 100,
-            headerName: "Multi-edit",
-          },
-          {
-            editorParams: {
-              multiEdit: true,
-              options: [
-                MenuHeaderItem("Header"),
-                {
-                  value: "1",
-                  label: "One",
-                  disabled: "Disabled for test",
-                },
-                { value: "2", label: "Two" },
-                MenuSeparator,
-                { value: "3", label: "Three" },
-              ],
-            },
-          },
-        ),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position3"]>(
-          {
-            field: "position3",
-            initialWidth: 65,
-            maxWidth: 150,
-            headerName: "Custom callback",
-          },
-          {
-            editorParams: {
-              multiEdit: true,
-              options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
-              onSelectedItem: async (selected) => {
-                await wait(2000);
-                selected.selectedRows.forEach((row) => (row.position3 = selected.value));
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "position2",
+          maxWidth: 100,
+          headerName: "Multi-edit",
+        },
+        {
+          editorParams: {
+            multiEdit: true,
+            options: [
+              MenuHeaderItem("Header"),
+              {
+                value: "1",
+                label: "One",
+                disabled: "Disabled for test",
               },
+              { value: "2", label: "Two" },
+              MenuSeparator,
+              { value: "3", label: "Three" },
+            ],
+          },
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "position3",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Custom callback",
+        },
+        {
+          editorParams: {
+            multiEdit: true,
+            options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
+            onSelectedItem: async (selected) => {
+              await wait(2000);
+              selected.selectedRows.forEach((row) => (row.position3 = selected.value));
             },
           },
-        ),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position"]>(
-          {
-            field: "position",
-            initialWidth: 65,
-            maxWidth: 150,
-            headerName: "Options Fn",
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "position",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Options Fn",
+        },
+        {
+          editorParams: {
+            filtered: "reload",
+            filterPlaceholder: "Search me...",
+            options: optionsFn,
+            optionsRequestCancel: () => {
+              // TODO wrap options in an abortable request
+              // When performing rest requests call the abort controller,
+              // otherwise you'll get multiple requests coming back in different order
+              // eslint-disable-next-line no-console
+              console.log("optionsRequestCancelled");
+            },
+            multiEdit: false,
           },
-          {
-            editorParams: {
-              filtered: "reload",
-              filterPlaceholder: "Search me...",
-              options: optionsFn,
-              optionsRequestCancel: () => {
-                // TODO wrap options in an abortable request
-                // When performing rest requests call the abort controller,
-                // otherwise you'll get multiple requests coming back in different order
-                // eslint-disable-next-line no-console
-                console.log("optionsRequestCancelled");
-              },
-              multiEdit: false,
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "position3",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Filtered",
+        },
+        {
+          editorParams: {
+            multiEdit: true,
+            filtered: "local",
+            filterPlaceholder: "Filter this",
+            options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
+          },
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "position4",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Filtered (object)",
+          valueGetter: (params) => params.data.position4?.desc,
+        },
+        {
+          editorParams: {
+            multiEdit: true,
+            filtered: "local",
+            filterPlaceholder: "Filter this",
+            options: optionsObjects.map((o) => {
+              return { value: o, label: o.desc, disabled: false };
+            }),
+          },
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "code",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Filter Selectable",
+          valueGetter: (params) => params.data.code,
+        },
+        {
+          editorParams: {
+            multiEdit: true,
+            filtered: "local",
+            filterPlaceholder: "Filter this",
+            options: optionsObjects.map((o) => {
+              return { value: o, label: o.desc, disabled: false };
+            }),
+            onSelectedItem: async (selected) => {
+              selected.selectedRows.forEach((row) => (row.code = selected.value.code));
+            },
+            onSelectFilter: async (selected) => {
+              selected.selectedRows.forEach((row) => (row.code = selected.value));
             },
           },
-        ),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position3"]>(
-          {
-            field: "position3",
-            initialWidth: 65,
-            maxWidth: 150,
-            headerName: "Filtered",
-          },
-          {
-            editorParams: {
-              multiEdit: true,
-              filtered: "local",
-              filterPlaceholder: "Filter this",
-              options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
-            },
-          },
-        ),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position4"]>(
-          {
-            field: "position4",
-            initialWidth: 65,
-            maxWidth: 150,
-            headerName: "Filtered (object)",
-            valueGetter: (params) => params.data.position4?.desc,
-          },
-          {
-            editorParams: {
-              multiEdit: true,
-              filtered: "local",
-              filterPlaceholder: "Filter this",
-              options: optionsObjects.map((o) => {
-                return { value: o, label: o.desc, disabled: false };
-              }),
-            },
-          },
-        ),
-        GridPopoverEditDropDown<ITestRow, ICode>(
-          {
-            field: "code",
-            initialWidth: 65,
-            maxWidth: 150,
-            headerName: "Filter Selectable",
-            valueGetter: (params) => params.data.code,
-          },
-          {
-            editorParams: {
-              multiEdit: true,
-              filtered: "local",
-              filterPlaceholder: "Filter this",
-              options: optionsObjects.map((o) => {
-                return { value: o, label: o.desc, disabled: false };
-              }),
-              onSelectedItem: async (selected) => {
-                selected.selectedRows.forEach((row) => (row.code = selected.value.code));
-              },
-              onSelectFilter: async (selected) => {
-                selected.selectedRows.forEach((row) => (row.code = selected.value));
-              },
-            },
-          },
-        ),
-      ] as ColDef[],
+        },
+      ),
+    ],
     [optionsFn, optionsObjects],
   );
 

--- a/src/stories/components/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/components/GridPopoutEditDropDown.stories.tsx
@@ -213,12 +213,6 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
             options: Array.from(Array(30).keys()).map((o) => {
               return { value: o, label: `${o}` };
             }),
-            onSelectedItem: async (selected) => {
-              selected.selectedRows.forEach((row) => (row.code = selected.value.code));
-            },
-            onSelectFilter: async (selected) => {
-              selected.selectedRows.forEach((row) => (row.code = selected.value));
-            },
           },
         },
       ),

--- a/src/stories/components/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/components/GridPopoutEditDropDown.stories.tsx
@@ -3,17 +3,11 @@ import "@linzjs/lui/dist/fonts";
 import "../../lui-overrides.scss";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
-import { UpdatingContextProvider } from "@contexts/UpdatingContextProvider";
+import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useCallback, useMemo, useState } from "react";
-import {
-  GridFormDropDown,
-  GridFormPopoutDropDownProps,
-  MenuHeaderItem,
-  MenuSeparator,
-  MenuSeparatorString,
-} from "@components/gridForm/GridFormDropDown";
+import { MenuHeaderItem, MenuSeparator, MenuSeparatorString } from "@components/gridForm/GridFormDropDown";
 import { ColDef } from "ag-grid-community";
 import { wait } from "@utils/util";
 import { GridCell } from "@components/GridCell";
@@ -29,11 +23,11 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ width: 1200, height: 400, display: "flex" }}>
-        <UpdatingContextProvider>
+        <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
           </GridContextProvider>
-        </UpdatingContextProvider>
+        </GridUpdatingContextProvider>
       </div>
     ),
   ],
@@ -90,117 +84,144 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
           initialWidth: 65,
           maxWidth: 85,
         }),
-        GridCell<ITestRow, GridFormPopoutDropDownProps<ITestRow, ITestRow["position"]>>({
-          field: "position",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Position",
-          cellEditorParams: {
-            form: GridFormDropDown,
-            options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
-            multiEdit: false,
+        GridPopoverEditDropDown<ITestRow, ITestRow["position"]>(
+          {
+            field: "position",
+            initialWidth: 65,
+            maxWidth: 150,
+            headerName: "Position",
           },
-        }),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position2"]>({
-          field: "position2",
-          maxWidth: 100,
-          headerName: "Multi-edit",
-          cellEditorParams: {
-            multiEdit: true,
-            options: [
-              MenuHeaderItem("Header"),
-              {
-                value: "1",
-                label: "One",
-                disabled: "Disabled for test",
+          {
+            editorParams: {
+              options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
+              multiEdit: false,
+            },
+          },
+        ),
+        GridPopoverEditDropDown<ITestRow, ITestRow["position2"]>(
+          {
+            field: "position2",
+            maxWidth: 100,
+            headerName: "Multi-edit",
+          },
+          {
+            editorParams: {
+              multiEdit: true,
+              options: [
+                MenuHeaderItem("Header"),
+                {
+                  value: "1",
+                  label: "One",
+                  disabled: "Disabled for test",
+                },
+                { value: "2", label: "Two" },
+                MenuSeparator,
+                { value: "3", label: "Three" },
+              ],
+            },
+          },
+        ),
+        GridPopoverEditDropDown<ITestRow, ITestRow["position3"]>(
+          {
+            field: "position3",
+            initialWidth: 65,
+            maxWidth: 150,
+            headerName: "Custom callback",
+          },
+          {
+            editorParams: {
+              multiEdit: true,
+              options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
+              onSelectedItem: async (selected) => {
+                await wait(2000);
+                selected.selectedRows.forEach((row) => (row.position3 = selected.value));
               },
-              { value: "2", label: "Two" },
-              MenuSeparator,
-              { value: "3", label: "Three" },
-            ],
-          },
-        }),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position3"]>({
-          field: "position3",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Custom callback",
-          cellEditorParams: {
-            multiEdit: true,
-            options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
-            onSelectedItem: async (selected) => {
-              await wait(2000);
-              selected.selectedRows.forEach((row) => (row.position3 = selected.value));
             },
           },
-        }),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position"]>({
-          field: "position",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Options Fn",
-          cellEditorParams: {
-            filtered: "reload",
-            filterPlaceholder: "Search me...",
-            options: optionsFn,
-            optionsRequestCancel: () => {
-              // TODO wrap options in an abortable request
-              // When performing rest requests call the abort controller,
-              // otherwise you'll get multiple requests coming back in different order
-              // eslint-disable-next-line no-console
-              console.log("optionsRequestCancelled");
-            },
-            multiEdit: false,
+        ),
+        GridPopoverEditDropDown<ITestRow, ITestRow["position"]>(
+          {
+            field: "position",
+            initialWidth: 65,
+            maxWidth: 150,
+            headerName: "Options Fn",
           },
-        }),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position3"]>({
-          field: "position3",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Filtered",
-          cellEditorParams: {
-            multiEdit: true,
-            filtered: "local",
-            filterPlaceholder: "Filter this",
-            options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
-          },
-        }),
-        GridPopoverEditDropDown<ITestRow, ITestRow["position4"]>({
-          field: "position4",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Filtered (object)",
-          valueGetter: (params) => params.data.position4?.desc,
-          cellEditorParams: {
-            multiEdit: true,
-            filtered: "local",
-            filterPlaceholder: "Filter this",
-            options: optionsObjects.map((o) => {
-              return { value: o, label: o.desc, disabled: false };
-            }),
-          },
-        }),
-        GridPopoverEditDropDown<ITestRow, ICode>({
-          field: "code",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Filter Selectable",
-          valueGetter: (params) => params.data.code,
-          cellEditorParams: {
-            multiEdit: true,
-            filtered: "local",
-            filterPlaceholder: "Filter this",
-            options: optionsObjects.map((o) => {
-              return { value: o, label: o.desc, disabled: false };
-            }),
-            onSelectedItem: async (selected) => {
-              selected.selectedRows.forEach((row) => (row.code = selected.value.code));
-            },
-            onSelectFilter: async (selected) => {
-              selected.selectedRows.forEach((row) => (row.code = selected.value));
+          {
+            editorParams: {
+              filtered: "reload",
+              filterPlaceholder: "Search me...",
+              options: optionsFn,
+              optionsRequestCancel: () => {
+                // TODO wrap options in an abortable request
+                // When performing rest requests call the abort controller,
+                // otherwise you'll get multiple requests coming back in different order
+                // eslint-disable-next-line no-console
+                console.log("optionsRequestCancelled");
+              },
+              multiEdit: false,
             },
           },
-        }),
+        ),
+        GridPopoverEditDropDown<ITestRow, ITestRow["position3"]>(
+          {
+            field: "position3",
+            initialWidth: 65,
+            maxWidth: 150,
+            headerName: "Filtered",
+          },
+          {
+            editorParams: {
+              multiEdit: true,
+              filtered: "local",
+              filterPlaceholder: "Filter this",
+              options: [null, "Architect", "Developer", "Product Owner", "Scrum Master", "Tester", "(other)"],
+            },
+          },
+        ),
+        GridPopoverEditDropDown<ITestRow, ITestRow["position4"]>(
+          {
+            field: "position4",
+            initialWidth: 65,
+            maxWidth: 150,
+            headerName: "Filtered (object)",
+            valueGetter: (params) => params.data.position4?.desc,
+          },
+          {
+            editorParams: {
+              multiEdit: true,
+              filtered: "local",
+              filterPlaceholder: "Filter this",
+              options: optionsObjects.map((o) => {
+                return { value: o, label: o.desc, disabled: false };
+              }),
+            },
+          },
+        ),
+        GridPopoverEditDropDown<ITestRow, ICode>(
+          {
+            field: "code",
+            initialWidth: 65,
+            maxWidth: 150,
+            headerName: "Filter Selectable",
+            valueGetter: (params) => params.data.code,
+          },
+          {
+            editorParams: {
+              multiEdit: true,
+              filtered: "local",
+              filterPlaceholder: "Filter this",
+              options: optionsObjects.map((o) => {
+                return { value: o, label: o.desc, disabled: false };
+              }),
+              onSelectedItem: async (selected) => {
+                selected.selectedRows.forEach((row) => (row.code = selected.value.code));
+              },
+              onSelectFilter: async (selected) => {
+                selected.selectedRows.forEach((row) => (row.code = selected.value));
+              },
+            },
+          },
+        ),
       ] as ColDef[],
     [optionsFn, optionsObjects],
   );

--- a/src/stories/components/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/components/GridPopoutEditDropDown.stories.tsx
@@ -200,6 +200,33 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
           field: "code",
           initialWidth: 65,
           maxWidth: 150,
+          headerName: "Max height",
+          valueGetter: (params) => params.data.code,
+        },
+        {
+          editorParams: {
+            maxRows: 2,
+            multiEdit: true,
+
+            filtered: "local",
+            filterPlaceholder: "Filter this",
+            options: Array.from(Array(30).keys()).map((o) => {
+              return { value: o, label: `${o}` };
+            }),
+            onSelectedItem: async (selected) => {
+              selected.selectedRows.forEach((row) => (row.code = selected.value.code));
+            },
+            onSelectFilter: async (selected) => {
+              selected.selectedRows.forEach((row) => (row.code = selected.value));
+            },
+          },
+        },
+      ),
+      GridPopoverEditDropDown(
+        {
+          field: "code",
+          initialWidth: 65,
+          maxWidth: 150,
           headerName: "Filter Selectable",
           valueGetter: (params) => params.data.code,
         },

--- a/src/stories/components/GridPopoutEditGeneric.stories.tsx
+++ b/src/stories/components/GridPopoutEditGeneric.stories.tsx
@@ -3,7 +3,7 @@ import "@linzjs/lui/dist/fonts";
 import "../../lui-overrides.scss";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
-import { UpdatingContextProvider } from "@contexts/UpdatingContextProvider";
+import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
@@ -20,11 +20,11 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ width: 1200, height: 400, display: "flex" }}>
-        <UpdatingContextProvider>
+        <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
           </GridContextProvider>
-        </UpdatingContextProvider>
+        </GridUpdatingContextProvider>
       </div>
     ),
   ],

--- a/src/stories/components/GridPopoutEditGeneric.stories.tsx
+++ b/src/stories/components/GridPopoutEditGeneric.stories.tsx
@@ -40,15 +40,20 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridCell({
-        field: "name",
-        headerName: "Popout Generic Edit",
-        maxWidth: 140,
-        cellEditorParams: {
-          form: FormTest,
-          multiEdit: false,
+      GridCell<IFormTestRow>(
+        {
+          field: "name",
+          headerName: "Popout Generic Edit",
+          maxWidth: 140,
         },
-      }),
+        {
+          editor: FormTest,
+          editorParams: {
+            a: 4,
+            multiEdit: false,
+          },
+        },
+      ),
     ],
     [],
   );

--- a/src/stories/components/GridPopoutEditGeneric.stories.tsx
+++ b/src/stories/components/GridPopoutEditGeneric.stories.tsx
@@ -7,7 +7,7 @@ import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvid
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
-import { GridCell } from "@components/GridCell";
+import { ColDefT, GridCell } from "@components/GridCell";
 import { FormTest, IFormTestRow } from "./FormTest";
 
 export default {
@@ -32,7 +32,7 @@ export default {
 
 const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
-  const columnDefs = useMemo(
+  const columnDefs: ColDefT<IFormTestRow>[] = useMemo(
     () => [
       GridCell({
         field: "id",
@@ -40,7 +40,7 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridCell<IFormTestRow>(
+      GridCell(
         {
           field: "name",
           headerName: "Popout Generic Edit",

--- a/src/stories/components/GridPopoutEditGenericTextArea.stories.tsx
+++ b/src/stories/components/GridPopoutEditGenericTextArea.stories.tsx
@@ -3,7 +3,7 @@ import "@linzjs/lui/dist/fonts";
 import "../../lui-overrides.scss";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
-import { UpdatingContextProvider } from "@contexts/UpdatingContextProvider";
+import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
@@ -23,11 +23,11 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ width: 1200, height: 400, display: "flex" }}>
-        <UpdatingContextProvider>
+        <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
           </GridContextProvider>
-        </UpdatingContextProvider>
+        </GridUpdatingContextProvider>
       </div>
     ),
   ],
@@ -43,70 +43,84 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridPopoverTextInput<IFormTestRow>({
-        field: "name",
-        headerName: "Text input",
-        maxWidth: 140,
-        cellEditorParams: {
-          required: true,
-          maxlength: 12,
-          placeholder: "Enter some text...",
-          validate: (value: string) => {
-            if (value === "never") return "The value 'never' is not allowed";
-            return null;
-          },
-          multiEdit: false,
-          onSave: async (selectedRows, value) => {
-            await wait(1000);
-            selectedRows.forEach((selectedRow) => (selectedRow["name"] = value));
-            return true;
+      GridPopoverTextInput<IFormTestRow>(
+        {
+          field: "name",
+          headerName: "Text input",
+          maxWidth: 140,
+        },
+        {
+          editorParams: {
+            required: true,
+            maxlength: 12,
+            placeholder: "Enter some text...",
+            validate: (value: string) => {
+              if (value === "never") return "The value 'never' is not allowed";
+              return null;
+            },
+            multiEdit: false,
+            onSave: async (selectedRows, value) => {
+              await wait(1000);
+              selectedRows.forEach((selectedRow) => (selectedRow["name"] = value));
+              return true;
+            },
           },
         },
-      }),
-      GridPopoverTextInput<IFormTestRow>({
-        field: "distance",
-        headerName: "Number input",
-        maxWidth: 140,
-        valueFormatter: (params) => {
-          const v = params.data.distance;
-          return v != null ? `${v}${params.colDef.cellEditorParams.units}` : v;
-        },
-        cellEditorParams: {
-          maxlength: 12,
-          placeholder: "Enter distance...",
-          units: "m",
-          validate: (value: string) => {
-            if (value.length && !isFloat(value)) return "Value must be a number";
-            return null;
-          },
-          multiEdit: false,
-          onSave: async (selectedRows, value) => {
-            await wait(1000);
-            selectedRows.forEach((selectedRow) => (selectedRow["distance"] = value.length ? parseFloat(value) : null));
-            return true;
+      ),
+      GridPopoverTextInput<IFormTestRow>(
+        {
+          field: "distance",
+          headerName: "Number input",
+          maxWidth: 140,
+          valueFormatter: (params) => {
+            const v = params.data.distance;
+            return v != null ? `${v}${params.colDef.cellEditorParams.units}` : v;
           },
         },
-      }),
-      GridPopoverTextArea<IFormTestRow>({
-        field: "plan",
-        headerName: "Text area",
-        maxWidth: 140,
-        cellEditorParams: {
-          required: true,
-          maxlength: 32,
-          placeholder: "Enter some text...",
-          multiEdit: true,
-          validate: (value: string) => {
-            if (value === "never") return "The value 'never' is not allowed";
-            return null;
-          },
-          onSave: async (selectedRows, value) => {
-            await wait(1000);
-            selectedRows.forEach((selectedRow) => (selectedRow["plan"] = value));
-            return true;
+        {
+          editorParams: {
+            maxlength: 12,
+            placeholder: "Enter distance...",
+            units: "m",
+            validate: (value: string) => {
+              if (value.length && !isFloat(value)) return "Value must be a number";
+              return null;
+            },
+            multiEdit: false,
+            onSave: async (selectedRows, value) => {
+              await wait(1000);
+              selectedRows.forEach(
+                (selectedRow) => (selectedRow["distance"] = value.length ? parseFloat(value) : null),
+              );
+              return true;
+            },
           },
         },
-      }),
+      ),
+      GridPopoverTextArea<IFormTestRow>(
+        {
+          field: "plan",
+          headerName: "Text area",
+          maxWidth: 140,
+        },
+        {
+          editorParams: {
+            required: true,
+            maxlength: 32,
+            placeholder: "Enter some text...",
+            multiEdit: true,
+            validate: (value: string) => {
+              if (value === "never") return "The value 'never' is not allowed";
+              return null;
+            },
+            onSave: async (selectedRows, value) => {
+              await wait(1000);
+              selectedRows.forEach((selectedRow) => (selectedRow["plan"] = value));
+              return true;
+            },
+          },
+        },
+      ),
     ],
     [],
   );

--- a/src/stories/components/GridPopoutEditGenericTextArea.stories.tsx
+++ b/src/stories/components/GridPopoutEditGenericTextArea.stories.tsx
@@ -7,7 +7,7 @@ import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvid
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
-import { GridCell } from "@components/GridCell";
+import { ColDefT, GridCell } from "@components/GridCell";
 import { IFormTestRow } from "./FormTest";
 import { isFloat, wait } from "@utils/util";
 import { GridPopoverTextArea } from "@components/gridPopoverEdit/GridPopoverTextArea";
@@ -35,7 +35,7 @@ export default {
 
 const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
-  const columnDefs = useMemo(
+  const columnDefs: ColDefT<IFormTestRow>[] = useMemo(
     () => [
       GridCell({
         field: "id",
@@ -43,7 +43,7 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridPopoverTextInput<IFormTestRow>(
+      GridPopoverTextInput(
         {
           field: "name",
           headerName: "Text input",
@@ -67,7 +67,7 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
           },
         },
       ),
-      GridPopoverTextInput<IFormTestRow>(
+      GridPopoverTextInput(
         {
           field: "distance",
           headerName: "Number input",
@@ -97,7 +97,7 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
           },
         },
       ),
-      GridPopoverTextArea<IFormTestRow>(
+      GridPopoverTextArea(
         {
           field: "plan",
           headerName: "Text area",

--- a/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
+++ b/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
@@ -3,7 +3,7 @@ import "@linzjs/lui/dist/fonts";
 import "../../lui-overrides.scss";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
-import { UpdatingContextProvider } from "@contexts/UpdatingContextProvider";
+import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
@@ -25,11 +25,11 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ width: 1200, height: 400, display: "flex" }}>
-        <UpdatingContextProvider>
+        <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
           </GridContextProvider>
-        </UpdatingContextProvider>
+        </GridUpdatingContextProvider>
       </div>
     ),
   ],
@@ -58,56 +58,64 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridPopoutEditMultiSelect<ITestRow, ITestRow["position"]>({
-        field: "position",
-        initialWidth: 65,
-        maxWidth: 150,
-        headerName: "Position",
-        cellEditorParams: {
-          multiEdit: false,
-          filtered: true,
-          filterPlaceholder: "Filter position",
-          options: [
-            { value: "a", label: "Architect" },
-            { value: "b", label: "Developer" },
-            { value: "c", label: "Product Owner" },
-            { value: "d", label: "Scrum Master" },
-            { value: "e", label: "Tester" },
-            MenuSeparator,
-            {
-              value: "f",
-              label: "Other",
-              subComponent: (props) => <GridSubComponentTextArea {...props} />,
+      GridPopoutEditMultiSelect<ITestRow, ITestRow["position"]>(
+        {
+          field: "position",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Position",
+        },
+        {
+          editorParams: {
+            multiEdit: false,
+            filtered: true,
+            filterPlaceholder: "Filter position",
+            options: [
+              { value: "a", label: "Architect" },
+              { value: "b", label: "Developer" },
+              { value: "c", label: "Product Owner" },
+              { value: "d", label: "Scrum Master" },
+              { value: "e", label: "Tester" },
+              MenuSeparator,
+              {
+                value: "f",
+                label: "Other",
+                subComponent: (props) => <GridSubComponentTextArea {...props} />,
+              },
+            ],
+            onSave: async (result: MultiSelectResult<ITestRow>) => {
+              // eslint-disable-next-line no-console
+              console.log(result);
+              await wait(1000);
+              return true;
             },
-          ],
-          onSave: async (result: MultiSelectResult<ITestRow>) => {
-            // eslint-disable-next-line no-console
-            console.log(result);
-            await wait(1000);
-            return true;
           },
         },
-      }),
-      GridPopoutEditMultiSelect<ITestRow, ITestRow["position2"]>({
-        field: "position2",
-        initialWidth: 65,
-        maxWidth: 150,
-        headerName: "Inital editor values ",
-        valueGetter: (props) => positionTwoMap[props.data.position2],
-        cellEditorParams: {
-          multiEdit: false,
-          filtered: true,
-          filterPlaceholder: "Filter position",
-          initialSelectedValues: (selectedRows) => [selectedRows[0].position2],
-          options: Object.entries(positionTwoMap).map(([k, v]) => ({ value: k, label: v })),
-          onSave: async (result: MultiSelectResult<ITestRow>) => {
-            // eslint-disable-next-line no-console
-            console.log(result);
-            await wait(1000);
-            return true;
+      ),
+      GridPopoutEditMultiSelect<ITestRow, ITestRow["position2"]>(
+        {
+          field: "position2",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Inital editor values ",
+          valueGetter: (props) => positionTwoMap[props.data.position2],
+        },
+        {
+          editorParams: {
+            multiEdit: false,
+            filtered: true,
+            filterPlaceholder: "Filter position",
+            initialSelectedValues: (selectedRows) => [selectedRows[0].position2],
+            options: Object.entries(positionTwoMap).map(([k, v]) => ({ value: k, label: v })),
+            onSave: async (result: MultiSelectResult<ITestRow>) => {
+              // eslint-disable-next-line no-console
+              console.log(result);
+              await wait(1000);
+              return true;
+            },
           },
         },
-      }),
+      ),
     ] as ColDef[];
   }, []);
 

--- a/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
+++ b/src/stories/components/GridPopoutEditMultiSelect.stories.tsx
@@ -8,11 +8,10 @@ import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
 import { MenuSeparator } from "@components/gridForm/GridFormDropDown";
-import { ColDef } from "ag-grid-community";
 import { wait } from "@utils/util";
 import { MultiSelectResult } from "@components/gridForm/GridFormMultiSelect";
 import { GridSubComponentTextArea } from "@components/GridSubComponentTextArea";
-import { GridCell } from "@components/GridCell";
+import { ColDefT, GridCell } from "@components/GridCell";
 import { GridPopoutEditMultiSelect } from "@components/gridPopoverEdit/GridPopoutEditMultiSelect";
 
 export default {
@@ -45,7 +44,7 @@ interface ITestRow {
 const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
 
-  const columnDefs = useMemo(() => {
+  const columnDefs: ColDefT<ITestRow>[] = useMemo(() => {
     const positionTwoMap: Record<string, string> = {
       "1": "One",
       "2": "Two",
@@ -58,7 +57,7 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridPopoutEditMultiSelect<ITestRow, ITestRow["position"]>(
+      GridPopoutEditMultiSelect(
         {
           field: "position",
           initialWidth: 65,
@@ -92,7 +91,7 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
           },
         },
       ),
-      GridPopoutEditMultiSelect<ITestRow, ITestRow["position2"]>(
+      GridPopoutEditMultiSelect(
         {
           field: "position2",
           initialWidth: 65,
@@ -116,7 +115,7 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
           },
         },
       ),
-    ] as ColDef[];
+    ];
   }, []);
 
   const rowData = useMemo(

--- a/src/stories/components/GridReadOnly.stories.tsx
+++ b/src/stories/components/GridReadOnly.stories.tsx
@@ -9,8 +9,8 @@ import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
 import { wait } from "@utils/util";
 import { GridPopoverMenu } from "@components/gridPopoverEdit/GridPopoverMenu";
+import { CellParams, ColDefT, GridCell } from "@components/GridCell";
 import { GridPopoverMessage } from "@components/gridPopoverEdit/GridPopoverMessage";
-import { GridCell } from "@components/GridCell";
 
 export default {
   title: "Components / Grids",
@@ -42,7 +42,7 @@ interface ITestRow {
 
 const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
   const [externalSelectedItems, setExternalSelectedItems] = useState<any[]>([]);
-  const columnDefs = useMemo(
+  const columnDefs: ColDefT<ITestRow>[] = useMemo(
     () => [
       GridCell({
         field: "id",
@@ -50,7 +50,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridCell<ITestRow>({
+      GridCell({
         field: "position",
         headerName: "Position",
         initialWidth: 65,
@@ -72,22 +72,25 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         initialWidth: 150,
         maxWidth: 200,
       }),
-      GridPopoverMessage<ITestRow>(
+      GridPopoverMessage(
         {
           headerName: "Popout message",
           cellRenderer: () => <>Click me!</>,
+          cellRendererParams: {
+            warning: () => "x",
+          },
         },
         {
           editorParams: {
-            message: async (cellParams) => {
+            message: async (formParams: CellParams<ITestRow>): Promise<string> => {
               await wait(1000);
-              return `There are ${cellParams.selectedRows.length} row(s) selected`;
+              return `There are ${formParams.selectedRows.length} row(s) selected`;
             },
             multiEdit: true,
           },
         },
       ),
-      GridPopoverMenu<ITestRow>(
+      GridPopoverMenu(
         {
           headerName: "Menu",
         },
@@ -131,7 +134,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
           },
         },
       ),
-      GridPopoverMenu<ITestRow>(
+      GridPopoverMenu(
         {
           headerName: "Menu disabled",
           editable: false,

--- a/src/stories/components/GridReadOnly.stories.tsx
+++ b/src/stories/components/GridReadOnly.stories.tsx
@@ -93,6 +93,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         },
         {
           editorParams: {
+            multiEdit: true,
             options: async (selectedItems) => {
               // Just doing a timeout here to demonstrate deferred loading
               await wait(500);

--- a/src/stories/components/GridReadOnly.stories.tsx
+++ b/src/stories/components/GridReadOnly.stories.tsx
@@ -3,7 +3,7 @@ import "@linzjs/lui/dist/fonts";
 import "../../lui-overrides.scss";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
-import { UpdatingContextProvider } from "@contexts/UpdatingContextProvider";
+import { GridUpdatingContextProvider } from "@contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "@contexts/GridContextProvider";
 import { Grid, GridProps } from "@components/Grid";
 import { useMemo, useState } from "react";
@@ -22,11 +22,11 @@ export default {
   decorators: [
     (Story) => (
       <div style={{ width: 1200, height: 400, display: "flex" }}>
-        <UpdatingContextProvider>
+        <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
           </GridContextProvider>
-        </UpdatingContextProvider>
+        </GridUpdatingContextProvider>
       </div>
     ),
   ],
@@ -50,7 +50,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         initialWidth: 65,
         maxWidth: 85,
       }),
-      GridCell<ITestRow, any>({
+      GridCell<ITestRow>({
         field: "position",
         headerName: "Position",
         initialWidth: 65,
@@ -72,65 +72,77 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         initialWidth: 150,
         maxWidth: 200,
       }),
-      GridPopoverMessage<ITestRow>({
-        headerName: "Popout message",
-        cellRenderer: () => <>Click me!</>,
-        cellEditorParams: {
-          message: async (selectedRows: ITestRow[]) => {
-            await wait(1000);
-            return `There are ${selectedRows.length} row(s) selected`;
-          },
-          multiEdit: true,
+      GridPopoverMessage<ITestRow>(
+        {
+          headerName: "Popout message",
+          cellRenderer: () => <>Click me!</>,
         },
-      }),
-      GridPopoverMenu<ITestRow>({
-        headerName: "Menu",
-        cellEditorParams: {
-          options: async (selectedItems) => {
-            // Just doing a timeout here to demonstrate deferred loading
-            await wait(500);
-            return [
-              {
-                label: "Single edit only",
-                action: async (selectedRows) => {
-                  alert(`Single-edit: ${selectedRows.length} rows`);
-                  await wait(1500);
-                  return true;
+        {
+          editorParams: {
+            message: async (cellParams) => {
+              await wait(1000);
+              return `There are ${cellParams.selectedRows.length} row(s) selected`;
+            },
+            multiEdit: true,
+          },
+        },
+      ),
+      GridPopoverMenu<ITestRow>(
+        {
+          headerName: "Menu",
+        },
+        {
+          editorParams: {
+            options: async (selectedItems) => {
+              // Just doing a timeout here to demonstrate deferred loading
+              await wait(500);
+              return [
+                {
+                  label: "Single edit only",
+                  action: async (selectedRows) => {
+                    alert(`Single-edit: ${selectedRows.length} rows`);
+                    await wait(1500);
+                    return true;
+                  },
+                  supportsMultiEdit: false,
                 },
-                supportsMultiEdit: false,
-              },
-              {
-                label: "Multi-edit",
-                action: async (selectedRows) => {
-                  alert(`Multi-edit: ${selectedRows.length} rows`);
-                  await wait(1500);
-                  return true;
+                {
+                  label: "Multi-edit",
+                  action: async (selectedRows) => {
+                    alert(`Multi-edit: ${selectedRows.length} rows`);
+                    await wait(1500);
+                    return true;
+                  },
+                  supportsMultiEdit: true,
                 },
-                supportsMultiEdit: true,
-              },
-              {
-                label: "Disabled item",
-                disabled: "Disabled for test",
-                supportsMultiEdit: true,
-              },
-              {
-                label: "Developer Only",
-                hidden: selectedItems.some((x) => x.position != "Developer"),
-                supportsMultiEdit: true,
-              },
-            ];
+                {
+                  label: "Disabled item",
+                  disabled: "Disabled for test",
+                  supportsMultiEdit: true,
+                },
+                {
+                  label: "Developer Only",
+                  hidden: selectedItems.some((x) => x.position != "Developer"),
+                  supportsMultiEdit: true,
+                },
+              ];
+            },
           },
         },
-      }),
-      GridPopoverMenu<ITestRow>({
-        headerName: "Menu disabled",
-        editable: false,
-        cellEditorParams: {
-          options: async () => {
-            return [];
+      ),
+      GridPopoverMenu<ITestRow>(
+        {
+          headerName: "Menu disabled",
+          editable: false,
+        },
+        {
+          editorParams: {
+            options: async () => {
+              return [];
+            },
           },
         },
-      }),
+      ),
     ],
     [],
   );


### PR DESCRIPTION
* Renamed UpdatingContext to GridUpdatingContext.
* Removed form type generics off grid cell.
* Moved cellEditorParams to editors params as second parameter so I can correctly apply generics.
e.g.
```
      GridPopoverEditBearing<ITestRow>(
        {
          field: "bearing1",
          headerName: "Bearing GCE",
          cellRendererParams: {
            warning: (props: any) => props.data.id == 1002 && "Testers are testing",
            info: (props: any) => props.data.id == 1001 && "Developers are developing",
          },
        },
        {
          editorParams: {
            multiEdit: false,
          },
        },
      ),
 ```


Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
