### PR TITLE
Issue/modal closes editor

### DIFF
--- a/src/components/GridPopoverHook.tsx
+++ b/src/components/GridPopoverHook.tsx
@@ -3,6 +3,7 @@ import { GridContext } from "../contexts/GridContext";
 import { GridBaseRow } from "./Grid";
 import { ControlledMenu } from "../react-menu3";
 import { GridPopoverContext } from "../contexts/GridPopoverContext";
+import { MenuCloseEvent } from "../react-menu3/types";
 
 export interface GridPopoverHookProps<RowType> {
   className: string | undefined;
@@ -45,7 +46,10 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
               anchorRef={anchorRef}
               saveButtonRef={saveButtonRef}
               menuClassName={"step-ag-grid-react-menu"}
-              onClose={(event: { reason: string }) => triggerSave(event.reason).then()}
+              onClose={(event: MenuCloseEvent) => {
+                if (event.reason === "blur") return;
+                triggerSave(event.reason).then();
+              }}
               viewScroll={"auto"}
               dontShrinkIfDirectionIsTop={true}
               className={props.className}

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -82,6 +82,7 @@ export const ControlledMenuFr = (
   const handleScreenEventForSave = useCallback(
     (ev: MouseEvent) => {
       if (!clickIsWithinMenu(ev)) {
+        console.log("clickIsWithinMenu: false")
         //!ev.currentTarget.contains(ev.relatedTarget || document.activeElement)) {
         ev.preventDefault();
         ev.stopPropagation();

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -86,7 +86,6 @@ export const ControlledMenuFr = (
   const handleScreenEventForSave = useCallback(
     (ev: MouseEvent) => {
       if (!clickIsWithinMenu(ev)) {
-        console.log("clickIsWithinMenu: false");
         ev.preventDefault();
         ev.stopPropagation();
         // FIXME There's an issue in React17

--- a/src/stories/grid/FormTest.tsx
+++ b/src/stories/grid/FormTest.tsx
@@ -1,7 +1,7 @@
 import "./FormTest.scss";
 
 import { useCallback, useState } from "react";
-import { LuiTextInput } from "@linzjs/lui";
+import { LuiAlertModal, LuiAlertModalButtons, LuiButton, LuiTextInput } from "@linzjs/lui";
 import { wait } from "../../utils/util";
 import { CellEditorCommon, CellParams } from "../../components/GridCell";
 import { useGridPopoverHook } from "../../components/GridPopoverHook";
@@ -35,9 +35,33 @@ export const FormTest = <RowType extends GridBaseRow>(_props: CellEditorCommon):
     // Close form
     return true;
   }, [nameType, numba, plan, props.selectedRows]);
+
+  const [showModal, setShowModal] = useState<boolean>(false);
+
   const { popoverWrapper } = useGridPopoverHook({ className: _props.className, save });
 
   return popoverWrapper(
+    <>
+    {showModal &&
+    <LuiAlertModal
+    data-testid="WarningAlertWithButtons-modal"
+    level="warning"
+    // If panel is popped out, append modal to poppped out window DOM, otherwise use default
+    //appendToElement={() => (poppedOut && popoutElement) || document.body}
+  >
+    <h2>Header</h2>
+    <p className="WarningAlertWithButtons-new-line">Description</p>
+    <LuiAlertModalButtons>
+        <LuiButton level="secondary" onClick={()=> {setShowModal(false);}} data-testid="WarningAlertWithButtons-cancel">
+          Cancel
+        </LuiButton>
+
+        <LuiButton level="primary" onClick={()=> {setShowModal(false);}} data-testid="WarningAlertWithButtons-ok" >
+          OK
+        </LuiButton>
+    </LuiAlertModalButtons>
+  </LuiAlertModal>
+}
     <div style={{ display: "flex", flexDirection: "row" }} className={"FormTest Grid-popoverContainer"}>
       <div className={"FormTest-textInput"}>
         <LuiTextInput label={"Name type"} value={nameType} onChange={(e) => setNameType(e.target.value)} />
@@ -46,8 +70,9 @@ export const FormTest = <RowType extends GridBaseRow>(_props: CellEditorCommon):
         <LuiTextInput label={"Number"} value={numba} onChange={(e) => setNumba(e.target.value)} />
       </div>
       <div className={"FormTest-textInput"}>
-        <LuiTextInput label={"Plan"} value={plan} onChange={(e) => setPlan(e.target.value)} />
+        <LuiButton onClick={() => setShowModal(true)}>Show Modal</LuiButton>
       </div>
-    </div>,
+    </div>
+    </>,
   );
 };


### PR DESCRIPTION
Modals created from editor forms close on blur of the underlying form if clicked on. This PR fixes this.

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [x] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
