### PR TITLE
feat/dropdown subcomponent

### DIFF
--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -218,21 +218,19 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
               <MenuHeader>{item.label}</MenuHeader>
             ) : filteredValues.includes(item.value) ? null : (
               <>
-                <MenuItem
-                  key={`${props.field}-${index}`}
-                  disabled={!!item.disabled}
-                  title={item.disabled && typeof item.disabled !== "boolean" ? item.disabled : ""}
-                  value={item.value}
-                  onClick={() => {
-                    const subComponentItem = subComponentValues.find(({ optionValue }) => optionValue === item.value);
-                    return subComponentItem
-                      ? selectItemHandler(item.value, subComponentItem.subComponentValue)
-                      : selectItemHandler(item.value);
-                  }}
-                >
-                  {item.label ?? (item.value == null ? `<${item.value}>` : `${item.value}`)}
-                </MenuItem>
-                {item.subComponent && (
+                {!item.subComponent ? (
+                  <MenuItem
+                    key={`${props.field}-${index}`}
+                    disabled={!!item.disabled}
+                    title={item.disabled && typeof item.disabled !== "boolean" ? item.disabled : ""}
+                    value={item.value}
+                    onClick={() => {
+                      selectItemHandler(item.value);
+                    }}
+                  >
+                    {item.label ?? (item.value == null ? `<${item.value}>` : `${item.value}`)}
+                  </MenuItem>
+                ) : (
                   <FocusableItem className={"LuiDeprecatedForms"} key={`${props.field}-${index}_subcomponent`}>
                     {(ref: any) =>
                       item.subComponent &&

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -233,7 +233,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
                   {item.label ?? (item.value == null ? `<${item.value}>` : `${item.value}`)}
                 </MenuItem>
                 {item.subComponent && (
-                  <FocusableItem className={"LuiDeprecatedForms"} key={`${item.value}_subcomponent`}>
+                  <FocusableItem className={"LuiDeprecatedForms"} key={`${props.field}-${index}_subcomponent`}>
                     {(ref: any) =>
                       item.subComponent &&
                       item.subComponent(
@@ -252,6 +252,15 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
                               });
                             }
                             setSubComponentValues(localSubComponentValues);
+                          },
+                          keyDown: (key: string) => {
+                            const subComponentItem = subComponentValues.find(
+                              ({ optionValue }) => optionValue === item.value,
+                            );
+                            if (key === "Enter" && subComponentItem) {
+                              selectItemHandler(item.value, subComponentItem.subComponentValue);
+                              ref.closeMenu();
+                            }
                           },
                         },
                         ref,

--- a/src/components/gridForm/GridFormSubComponentTextInput.tsx
+++ b/src/components/gridForm/GridFormSubComponentTextInput.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { TextInputFormatted } from "../../lui/TextInputFormatted";
+
+export interface GridFormSubComponentTextInput {
+  setValue: (value: string) => void;
+  keyDown: (key: string) => void;
+  placeholder?: string;
+}
+
+export const GridFormSubComponentTextInput = ({ keyDown, placeholder, setValue }: GridFormSubComponentTextInput) => {
+  const placeholderText = placeholder || "Other...";
+  const [inputValue, setInputValue] = useState("");
+  return (
+    <>
+      <TextInputFormatted
+        value={inputValue}
+        onChange={(e) => {
+          const value = e.target.value;
+          setValue(value);
+          setInputValue(value);
+        }}
+        inputProps={{
+          onKeyDown: (k: any) => keyDown(k.key),
+          placeholder: placeholderText,
+          onMouseEnter: (e) => {
+            if (document.activeElement != e.currentTarget) {
+              e.currentTarget.focus();
+            }
+          },
+        }}
+      />
+    </>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export { GridPopoverEditDropDown } from "./components/gridPopoverEdit/GridPopove
 export { GridPopoverMessage } from "./components/gridPopoverEdit/GridPopoverMessage";
 export { GridPopoverTextArea } from "./components/gridPopoverEdit/GridPopoverTextArea";
 export { GridPopoverTextInput } from "./components/gridPopoverEdit/GridPopoverTextInput";
+export { GridFormSubComponentTextInput } from "./components/gridForm/GridFormSubComponentTextInput";
 export * from "./components/gridForm/GridFormDropDown";
 export * from "./components/gridForm/GridFormMultiSelect";
 export * from "./components/gridForm/GridFormPopoutMenu";

--- a/src/stories/grid/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/grid/GridPopoutEditDropDown.stories.tsx
@@ -12,6 +12,7 @@ import { MenuHeaderItem, MenuSeparator, MenuSeparatorString } from "../../compon
 import { wait } from "../../utils/util";
 import { ColDefT, GridCell } from "../../components/GridCell";
 import { GridPopoverEditDropDown } from "../../components/gridPopoverEdit/GridPopoverEditDropDown";
+import { GridFormSubComponentTextInput } from "../../components/gridForm/GridFormSubComponentTextInput";
 
 export default {
   title: "Components / Grids",
@@ -40,6 +41,7 @@ interface ITestRow {
   position3: string | null;
   position4: ICode | null;
   code: string | null;
+  sub: string | null;
 }
 
 interface ICode {
@@ -243,11 +245,11 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
       ),
       GridPopoverEditDropDown(
         {
-          field: "code",
+          field: "sub",
           initialWidth: 65,
           maxWidth: 150,
           headerName: "Subcomponent",
-          valueGetter: (params) => params.data.code,
+          valueGetter: (params) => params.data.sub,
         },
         {
           multiEdit: true,
@@ -256,17 +258,19 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
             filterPlaceholder: "Filter this",
             options: [
               {
-                value: "first",
+                value: "one",
                 label: "One",
               },
               {
-                value: "second",
+                value: "two",
                 label: "Two",
               },
               {
                 value: "oth",
                 label: "Other",
-                subComponent: (props) => <SubComponent {...props} />,
+                subComponent: (props) => (
+                  <GridFormSubComponentTextInput {...props} placeholder={"Subcomponent value"} />
+                ),
               },
             ],
             onSelectedItem: async (selected) => {
@@ -287,6 +291,7 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
       position3: "Tester",
       position4: { code: "O1", desc: "Object One" },
       code: "O1",
+      sub: "two",
     },
     {
       id: 1001,
@@ -295,6 +300,7 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
       position3: "Developer",
       position4: { code: "O2", desc: "Object Two" },
       code: "O2",
+      sub: "one",
     },
   ] as ITestRow[]);
 
@@ -307,27 +313,6 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
       rowData={rowData}
       domLayout={"autoHeight"}
     />
-  );
-};
-
-interface SubComponentProps {
-  setValue: (value: string) => void;
-  keyDown: (key: string) => void;
-}
-
-const SubComponent = (props: SubComponentProps) => {
-  const [inputValue, setInputValue] = useState("");
-  return (
-    <div>
-      <input
-        value={inputValue}
-        onChange={(e) => {
-          setInputValue(e.target.value);
-          props.setValue(inputValue);
-        }}
-        onKeyDown={(k) => props.keyDown(k.key)}
-      />
-    </div>
   );
 };
 

--- a/src/stories/grid/GridPopoutEditDropDown.stories.tsx
+++ b/src/stories/grid/GridPopoutEditDropDown.stories.tsx
@@ -241,6 +241,40 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
           },
         },
       ),
+      GridPopoverEditDropDown(
+        {
+          field: "code",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Subcomponent",
+          valueGetter: (params) => params.data.code,
+        },
+        {
+          multiEdit: true,
+          editorParams: {
+            filtered: "local",
+            filterPlaceholder: "Filter this",
+            options: [
+              {
+                value: "first",
+                label: "One",
+              },
+              {
+                value: "second",
+                label: "Two",
+              },
+              {
+                value: "oth",
+                label: "Other",
+                subComponent: (props) => <SubComponent {...props} />,
+              },
+            ],
+            onSelectedItem: async (selected) => {
+              console.log("onSelectedItem", selected);
+            },
+          },
+        },
+      ),
     ],
     [optionsFn, optionsObjects],
   );
@@ -273,6 +307,27 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
       rowData={rowData}
       domLayout={"autoHeight"}
     />
+  );
+};
+
+interface SubComponentProps {
+  setValue: (value: string) => void;
+  keyDown: (key: string) => void;
+}
+
+const SubComponent = (props: SubComponentProps) => {
+  const [inputValue, setInputValue] = useState("");
+  return (
+    <div>
+      <input
+        value={inputValue}
+        onChange={(e) => {
+          setInputValue(e.target.value);
+          props.setValue(inputValue);
+        }}
+        onKeyDown={(k) => props.keyDown(k.key)}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
DESCRIPTION of the task, STORY/TASK number and link if applicable (e.g. SURVEY-100)

Allow any number of dropdown items to include a subcomponent that accepts a keyDown and setValue callbacks so the value can be recorded in the menu. The keyDown callback allows the menu to be saved and closed on 'Enter'. 

I am not sure if the is the "right" way to do this, but it appears to work. Any comments on how this could be done better would be much appreciated. 

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
