### PR TITLE
fix: opening modal from an editor closing the popover

### DIFF
--- a/src/components/GridPopoverHook.tsx
+++ b/src/components/GridPopoverHook.tsx
@@ -47,7 +47,6 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
               saveButtonRef={saveButtonRef}
               menuClassName={"step-ag-grid-react-menu"}
               onClose={(event: MenuCloseEvent) => {
-                if (event.reason === "blur") return;
                 triggerSave(event.reason).then();
               }}
               viewScroll={"auto"}

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -76,16 +76,16 @@ export const ControlledMenuFr = (
     ],
   );
 
-  const clickIsWithinMenu = useCallback(
-    (ev: MouseEvent) =>
-      hasParentClass("szh-menu--state-open", ev.target as Node) ||
-      (closeMenuExclusionClassName && hasParentClass(closeMenuExclusionClassName, ev.target as Node)),
+  const isWithinMenu = useCallback(
+    (target: EventTarget | null) =>
+      hasParentClass("szh-menu--state-open", target as Node) ||
+      (closeMenuExclusionClassName && hasParentClass(closeMenuExclusionClassName, target as Node)),
     [closeMenuExclusionClassName],
   );
 
   const handleScreenEventForSave = useCallback(
     (ev: MouseEvent) => {
-      if (!clickIsWithinMenu(ev)) {
+      if (!isWithinMenu(ev.target)) {
         ev.preventDefault();
         ev.stopPropagation();
         // FIXME There's an issue in React17
@@ -107,17 +107,17 @@ export const ControlledMenuFr = (
         }
       }
     },
-    [clickIsWithinMenu, onClose, saveButtonRef, skipOpen],
+    [isWithinMenu, onClose, saveButtonRef, skipOpen],
   );
 
   const handleScreenEventForCancel = useCallback(
     (ev: MouseEvent) => {
-      if (!clickIsWithinMenu(ev)) {
+      if (!isWithinMenu(ev)) {
         ev.preventDefault();
         ev.stopPropagation();
       }
     },
-    [clickIsWithinMenu],
+    [isWithinMenu],
   );
 
   useEffect(() => {
@@ -183,7 +183,8 @@ export const ControlledMenuFr = (
   };
 
   const onBlur = (e: FocusEvent) => {
-    if (isMenuOpen(state) && !e.currentTarget.contains(e.relatedTarget || document.activeElement)) {
+    if (isMenuOpen(state) && !e.currentTarget.contains(e.relatedTarget || document.activeElement) 
+    && !isWithinMenu(e.relatedTarget)) {
       safeCall(onClose, { reason: CloseReason.BLUR });
 
       // If a user clicks on the menu button when a menu is open, we need to close the menu.


### PR DESCRIPTION
Having a editor form open a modal was causing the form to close and/or not allowing the modal to be interacting with. 

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
