### PR TITLE
fix: action button manages own state

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@linzjs/step-ag-grid",
   "repository": "github:linz/step-ag-grid.git",
   "license": "MIT",
-  "version": "2.1.3",
+  "version": "2.4.1",
   "keywords": [
     "aggrid",
     "ag-grid",

--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -12,14 +12,14 @@ import { GenericCellColDef } from "../gridRender/GridRenderGenericCell";
  */
 export const GridPopoverMenu = <RowType extends GridBaseRow>(
   colDef: GenericCellColDef<RowType>,
-  props: GenericCellEditorProps<GridFormPopoutMenuProps<RowType>>,
+  custom: GenericCellEditorProps<GridFormPopoutMenuProps<RowType>>,
 ): ColDefT<RowType> =>
   GridCell<RowType, GridFormPopoutMenuProps<RowType>>(
     {
       maxWidth: 64,
       editable: colDef.editable != null ? colDef.editable : true,
       cellRenderer: GridRenderPopoutMenuCell,
-      cellClass: colDef?.cellEditorParams?.multiEdit !== false ? GenericMultiEditCellClass : undefined,
+      cellClass: custom?.multiEdit ? GenericMultiEditCellClass : undefined,
       ...colDef,
       cellRendererParams: {
         // Menus open on single click, this parameter is picked up in Grid.tsx
@@ -28,6 +28,6 @@ export const GridPopoverMenu = <RowType extends GridBaseRow>(
     },
     {
       editor: GridFormPopoutMenu,
-      ...props,
+      ...custom,
     },
   );

--- a/src/stories/components/ActionButton.stories.tsx
+++ b/src/stories/components/ActionButton.stories.tsx
@@ -3,7 +3,7 @@ import "@linzjs/lui/dist/fonts";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
 import { ActionButton } from "../../lui/ActionButton";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { wait } from "../../utils/util";
 
 export default {
@@ -13,21 +13,10 @@ export default {
 } as ComponentMeta<typeof ActionButton>;
 
 const ActionButtonTemplate: ComponentStory<typeof ActionButton> = () => {
-  const [inProgress, setInProgress] = useState(false);
   const performAction = useCallback(async () => {
-    setInProgress(true);
     await wait(1000);
-    setInProgress(false);
   }, []);
-  return (
-    <ActionButton
-      icon={"ic_add"}
-      name={"Add new row"}
-      inProgressName={"Adding..."}
-      inProgress={inProgress}
-      onClick={performAction}
-    />
-  );
+  return <ActionButton icon={"ic_add"} name={"Add new row"} inProgressName={"Adding..."} onAction={performAction} />;
 };
 
 export const ActionButtonSimple = ActionButtonTemplate.bind({});

--- a/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
+++ b/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
@@ -155,14 +155,10 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
     [rowData],
   );
 
-  const [inProgress, setInProgress] = useState(false);
-
   const addRowAction = useCallback(async () => {
-    setInProgress(true);
     await wait(1000);
     const lastRow = rowData[rowData.length - 1];
     setRowData([...rowData, { id: lastRow.id + 1, name: "?", nameType: "?", numba: "?", plan: "", distance: null }]);
-    setInProgress(false);
   }, [rowData]);
 
   return (
@@ -175,13 +171,7 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         rowData={rowData}
         domLayout={"autoHeight"}
       />
-      <ActionButton
-        icon={"ic_add"}
-        name={"Add new row"}
-        inProgressName={"Adding..."}
-        inProgress={inProgress}
-        onClick={addRowAction}
-      />
+      <ActionButton icon={"ic_add"} name={"Add new row"} inProgressName={"Adding..."} onAction={addRowAction} />
     </>
   );
 };

--- a/src/stories/grid/GridPopoutEditMultiSelect.stories.tsx
+++ b/src/stories/grid/GridPopoutEditMultiSelect.stories.tsx
@@ -13,6 +13,7 @@ import { wait } from "../../utils/util";
 import { GridSubComponentTextArea } from "../../components/GridSubComponentTextArea";
 import { ColDefT, GridCell } from "../../components/GridCell";
 import { GridPopoutEditMultiSelect } from "../../components/gridPopoverEdit/GridPopoutEditMultiSelect";
+import { partition } from "lodash-es";
 
 export default {
   title: "Components / Grids",
@@ -91,11 +92,9 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
               console.log("multiSelect result", { selectedRows, selectedOptions });
 
               await wait(1000);
-              const normalValues = selectedOptions.filter((o) => !o.subComponent).map((o) => o.label);
-              const subValues = selectedOptions.filter((o) => o.subComponent).map((o) => o.subValue);
-              selectedRows.forEach((row) => {
-                row.position = [...normalValues, ...subValues].join(", ");
-              });
+              const [subValues, normalValues] = partition(selectedOptions, (o) => o.subComponent);
+              const newValue = [...normalValues.map((o) => o.label), ...subValues.map((o) => o.subValue)].join(", ");
+              selectedRows.forEach((row) => (row.position = newValue));
               return true;
             },
           },

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -159,6 +159,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
   return (
     <Grid
       {...props}
+      selectable={true}
       externalSelectedItems={externalSelectedItems}
       setExternalSelectedItems={setExternalSelectedItems}
       columnDefs={columnDefs}


### PR DESCRIPTION
fix: action button manages own state, and now external state setter

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
