### PR TITLE
fix: sizeColumnsToFit errors in test

### DIFF
--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -223,7 +223,8 @@ export const GridContextProvider = (props: GridContextProps): ReactElement => {
    */
   const sizeColumnsToFit = (): void => {
     gridApiOp((gridApi) => {
-      gridApi.sizeColumnsToFit();
+      // Hide size columns to fit errors in tests
+      document.body.clientWidth && gridApi.sizeColumnsToFit();
     });
   };
 


### PR DESCRIPTION
fix: sizeColumnsToFit errors in test

In test documents have zero size which causes warnings.  This checks doc clientWidth before calling sizeColumnsToFit.