### PR TITLE
feat: subcomponents-in-popover-menus, focus inputs on mouseover

### DIFF
--- a/src/components/GridSubComponentTextArea.tsx
+++ b/src/components/GridSubComponentTextArea.tsx
@@ -49,12 +49,6 @@ export const GridSubComponentTextArea = (props: GridSubComponentTextAreaProps): 
       <TextInputFormatted
         className={"free-text-input"}
         value={value}
-        onMouseEnter={(e) => {
-          if (document.activeElement != e.currentTarget) {
-            e.currentTarget.focus();
-            e.currentTarget.selectionStart = e.currentTarget.value.length;
-          }
-        }}
         onChange={(e) => setValue(e.target.value)}
         error={validate(value)}
         inputProps={{

--- a/src/components/gridForm/GridFormTextInput.tsx
+++ b/src/components/gridForm/GridFormTextInput.tsx
@@ -63,12 +63,6 @@ export const GridFormTextInput = <RowType extends GridBaseRow>(_props: GridFormT
         onChange={(e) => setValue(e.target.value)}
         error={invalid()}
         formatted={props.units}
-        onMouseEnter={(e) => {
-          if (document.activeElement != e.currentTarget) {
-            e.currentTarget.focus();
-            e.currentTarget.selectionStart = e.currentTarget.value.length;
-          }
-        }}
         inputProps={{
           style: { width: "100%" },
           placeholder: props.placeholder,

--- a/src/lui/TextAreaInput.tsx
+++ b/src/lui/TextAreaInput.tsx
@@ -34,7 +34,19 @@ export const TextAreaInput = (props: LuiTextAreaInputProps) => {
         <div className="LuiTextAreaInput-wrapper">
           {" "}
           {/* wrapper div used for error styling */}
-          <textarea id={id} value={props.value} onChange={props.onChange} rows={5} {...props.inputProps} />
+          <textarea
+            id={id}
+            value={props.value}
+            onChange={props.onChange}
+            rows={5}
+            {...props.inputProps}
+            onMouseEnter={(e) => {
+              if (document.activeElement != e.currentTarget) {
+                e.currentTarget.focus();
+                e.currentTarget.selectionStart = e.currentTarget.value.length;
+              }
+            }}
+          />
         </div>
       </label>
 

--- a/src/lui/TextInputFormatted.tsx
+++ b/src/lui/TextInputFormatted.tsx
@@ -24,8 +24,6 @@ export interface LuiTextInputProps {
 
   placeholder?: string;
   formatted?: string;
-
-  onMouseEnter?: (e: React.MouseEvent<HTMLTextAreaElement>) => void;
 }
 
 export const TextInputFormatted = (props: LuiTextInputProps): JSX.Element => {
@@ -48,6 +46,9 @@ export const TextInputFormatted = (props: LuiTextInputProps): JSX.Element => {
           onChange={props.onChange}
           onFocus={props.onFocus}
           onClick={props.onClick}
+          onMouseEnter={(e) => {
+            e.currentTarget.focus();
+          }}
           {...props.inputProps}
         />
         <span className={"LuiTextInput-formatted"}>{props.formatted}</span>

--- a/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
+++ b/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
@@ -143,7 +143,6 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
                 action: async (selectedRows) => {
                   await wait(1500);
                   setRowData(rowData.filter((data) => !selectedRows.some((row) => row.id == data.id)));
-                  return true;
                 },
                 supportsMultiEdit: true,
               },

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -12,6 +12,8 @@ import { wait } from "../../utils/util";
 import { GridPopoverMenu } from "../../components/gridPopoverEdit/GridPopoverMenu";
 import { ColDefT, GridCell } from "../../components/GridCell";
 import { GridPopoverMessage } from "../../components/gridPopoverEdit/GridPopoverMessage";
+import { GridSubComponentTextArea } from "../../components/GridSubComponentTextArea";
+import { MenuOption } from "../../components/gridForm/GridFormPopoverMenu";
 
 export default {
   title: "Components / Grids",
@@ -105,7 +107,6 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
                   action: async (selectedRows) => {
                     alert(`Single-edit: ${selectedRows.length} rows`);
                     await wait(1500);
-                    return true;
                   },
                   supportsMultiEdit: false,
                 },
@@ -114,7 +115,6 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
                   action: async (selectedRows) => {
                     alert(`Multi-edit: ${selectedRows.length} rows`);
                     await wait(1500);
-                    return true;
                   },
                   supportsMultiEdit: true,
                 },
@@ -128,7 +128,18 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
                   hidden: selectedItems.some((x) => x.position != "Developer"),
                   supportsMultiEdit: true,
                 },
-              ];
+                {
+                  label: "Other",
+                  supportsMultiEdit: true,
+                  action: (_, menuOptionResult) => {
+                    console.log(menuOptionResult);
+                    alert(`Sub selected value was ${JSON.stringify(menuOptionResult.subValue)}`);
+                  },
+                  subComponent: () => (
+                    <GridSubComponentTextArea placeholder={"Other"} maxLength={2} required defaultValue={""} />
+                  ),
+                },
+              ] as MenuOption<ITestRow>[];
             },
           },
         },


### PR DESCRIPTION
* Action handlers now return the menu option clicked plus any subcomponent values
* Action handlers no longer return true/false, as it wasn't used I removed it.
* Mouse over input will trigger input focus
