### PR TITLE
BREAKING CHANGE: forms now get values from context

### DIFF
--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -9,15 +9,14 @@ import {
 } from "./gridRender/GridRenderGenericCell";
 import { ColDef, ICellEditorParams, ICellRendererParams } from "ag-grid-community";
 import { GridLoadableCell } from "./GridLoadableCell";
-import { GridIcon } from "../components/GridIcon";
+import { GridIcon } from "./GridIcon";
 import { ValueFormatterParams } from "ag-grid-community/dist/lib/entities/colDef";
-import { GridPopoverContext } from "../contexts/GridPopoverContext";
 import { GridPopoverContextProvider } from "../contexts/GridPopoverContextProvider";
 
 export interface GenericCellEditorProps<E> {
   multiEdit?: boolean;
   editor?: (editorProps: E) => JSX.Element;
-  editorParams?: E; // Omit<E, keyof CellParams<IFormTestRow>>
+  editorParams?: E;
 }
 
 export const GridCellRenderer = (props: ICellRendererParams) => {
@@ -91,37 +90,19 @@ export interface CellEditorCommon {
   className?: string | undefined;
 }
 
-export interface CellParams<RowType extends GridBaseRow> {
-  value: any;
-  data: RowType;
-  field: string | undefined;
-  selectedRows: RowType[];
-}
-
 // TODO memo?
 export const GenericCellEditorComponent = (editor: (props: any) => JSX.Element) =>
-  forwardRef(function GenericCellEditorComponent2(props: ICellEditorParams, _) {
-    return (
-      <GridPopoverContextProvider>
-        <GenericCellEditorComponent3 {...{ ...props, editor }} />
-      </GridPopoverContextProvider>
-    );
+  forwardRef(function GenericCellEditorComponentFr(props: ICellEditorParams, _) {
+    return <GenericCellEditorComponentImpl {...{ ...props, editor }} />;
   });
 
-const GenericCellEditorComponent3 = (props: ICellEditorParams & { editor: (props: any) => JSX.Element }) => {
-  const { setProps, propsRef } = useContext(GridPopoverContext);
-
+const GenericCellEditorComponentImpl = (props: ICellEditorParams & { editor: (props: any) => JSX.Element }) => {
   const { colDef } = props;
-  const { cellEditorParams } = colDef;
-  const multiEdit = cellEditorParams?.multiEdit ?? false;
-
-  // TODO don't need all these props in context
-  setProps(props, multiEdit);
 
   return (
-    <>
+    <GridPopoverContextProvider props={props}>
       {<colDef.cellRenderer {...props} />}
-      {props?.editor && <props.editor {...cellEditorParams} {...propsRef.current} />}
-    </>
+      {props?.editor && <props.editor {...props} />}
+    </GridPopoverContextProvider>
   );
 };

--- a/src/components/GridPopoverHook.tsx
+++ b/src/components/GridPopoverHook.tsx
@@ -12,7 +12,7 @@ export interface GridPopoverHookProps<RowType> {
 
 export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopoverHookProps<RowType>) => {
   const { stopEditing } = useContext(GridContext);
-  const { anchorRef, saving, propsRef } = useContext(GridPopoverContext);
+  const { anchorRef, saving, updateValue } = useContext(GridPopoverContext);
   const saveButtonRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setOpen] = useState(false);
 
@@ -22,16 +22,12 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
 
   const triggerSave = useCallback(
     async (reason?: string) => {
-      if (
-        reason == "cancel" ||
-        !props.save ||
-        (propsRef.current?.updateValue && (await propsRef.current?.updateValue(props.save)))
-      ) {
+      if (reason == "cancel" || !props.save || (updateValue && (await updateValue(props.save)))) {
         setOpen(false);
         stopEditing();
       }
     },
-    [props, stopEditing, propsRef],
+    [props.save, stopEditing, updateValue],
   );
 
   const popoverWrapper = useCallback(

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -57,8 +57,8 @@ export interface GridFormPopoutDropDownProps<RowType extends GridBaseRow, ValueT
 export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
   props: GridFormPopoutDropDownProps<RowType, ValueType>,
 ) => {
-  const { selectedRows, field } = useContext(GridPopoverContext);
-  const { updatingCells, stopEditing } = useContext(GridContext);
+  const { selectedRows, field, updateValue } = useContext(GridPopoverContext);
+  const { stopEditing } = useContext(GridContext);
 
   const [filter, setFilter] = useState("");
   const [filteredValues, setFilteredValues] = useState<any[]>([]);
@@ -67,8 +67,8 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
   const [subComponentValues, setSubComponentValues] = useState<{ optionValue: any; subComponentValue: any }[]>([]);
 
   const selectItemHandler = useCallback(
-    async (value: ValueType, subComponentValue?: ValueType): Promise<boolean> => {
-      return await updatingCells({ selectedRows: selectedRows, field }, async (selectedRows) => {
+    async (value: ValueType, subComponentValue?: ValueType): Promise<boolean> =>
+      updateValue(async (selectedRows) => {
         const hasChanged = selectedRows.some((row) => row[field as keyof RowType] !== value);
         if (hasChanged) {
           if (props.onSelectedItem) {
@@ -78,21 +78,17 @@ export const GridFormDropDown = <RowType extends GridBaseRow, ValueType>(
           }
         }
         return true;
-      });
-    },
-    [field, props, selectedRows, updatingCells],
+      }),
+    [field, props, updateValue],
   );
 
   const selectFilterHandler = useCallback(
-    async (value: string): Promise<boolean> => {
-      return await updatingCells({ selectedRows: selectedRows, field }, async (selectedRows) => {
-        if (props.onSelectFilter) {
-          await props.onSelectFilter({ selectedRows, value });
-        }
+    async (value: string) =>
+      updateValue(async (selectedRows) => {
+        props.onSelectFilter && (await props.onSelectFilter({ selectedRows, value }));
         return true;
-      });
-    },
-    [field, props, selectedRows, updatingCells],
+      }),
+    [props, updateValue],
   );
 
   // Load up options list if it's async function

--- a/src/components/gridForm/GridFormEditBearing.tsx
+++ b/src/components/gridForm/GridFormEditBearing.tsx
@@ -1,11 +1,12 @@
 import "../../styles/GridFormEditBearing.scss";
 
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { GridBaseRow } from "../Grid";
 import { TextInputFormatted } from "../../lui/TextInputFormatted";
 import { bearingNumberParser, bearingStringValidator, convertDDToDMS } from "../../utils/bearing";
 import { useGridPopoverHook } from "../GridPopoverHook";
-import { CellEditorCommon, CellParams } from "../GridCell";
+import { CellEditorCommon } from "../GridCell";
+import { GridPopoverContext } from "../../contexts/GridPopoverContext";
 
 export interface GridFormEditBearingProps<RowType extends GridBaseRow> extends CellEditorCommon {
   placeHolder?: string;
@@ -13,22 +14,21 @@ export interface GridFormEditBearingProps<RowType extends GridBaseRow> extends C
   onSave?: (selectedRows: RowType[], value: number | null) => Promise<boolean>;
 }
 
-export const GridFormEditBearing = <RowType extends GridBaseRow>(_props: GridFormEditBearingProps<RowType>) => {
-  const props = _props as GridFormEditBearingProps<RowType> & CellParams<RowType>;
-  const [value, setValue] = useState<string>(`${props.value ?? ""}`);
+export const GridFormEditBearing = <RowType extends GridBaseRow>(props: GridFormEditBearingProps<RowType>) => {
+  const { field, value: initialValue } = useContext(GridPopoverContext);
+  const [value, setValue] = useState<string>(`${initialValue ?? ""}`);
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {
       if (bearingStringValidator(value)) return false;
       const parsedValue = bearingNumberParser(value);
       // Value didn't change so don't save just cancel
-      if (parsedValue === props.value) {
+      if (parsedValue === initialValue) {
         return true;
       }
 
       if (props.onSave) {
         return await props.onSave(selectedRows, parsedValue);
       } else {
-        const field = props.field;
         if (field == null) {
           console.error("field is not defined in ColDef");
         } else {
@@ -37,7 +37,7 @@ export const GridFormEditBearing = <RowType extends GridBaseRow>(_props: GridFor
       }
       return true;
     },
-    [props, value],
+    [field, initialValue, props, value],
   );
   const { triggerSave, popoverWrapper } = useGridPopoverHook({ className: props.className, save });
 

--- a/src/components/gridForm/GridFormEditBearing.tsx
+++ b/src/components/gridForm/GridFormEditBearing.tsx
@@ -16,7 +16,9 @@ export interface GridFormEditBearingProps<RowType extends GridBaseRow> extends C
 
 export const GridFormEditBearing = <RowType extends GridBaseRow>(props: GridFormEditBearingProps<RowType>) => {
   const { field, value: initialValue } = useContext(GridPopoverContext);
+
   const [value, setValue] = useState<string>(`${initialValue ?? ""}`);
+
   const save = useCallback(
     async (selectedRows: RowType[]): Promise<boolean> => {
       if (bearingStringValidator(value)) return false;

--- a/src/components/gridForm/GridFormMessage.tsx
+++ b/src/components/gridForm/GridFormMessage.tsx
@@ -1,24 +1,25 @@
 import clsx from "clsx";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
 import { GridBaseRow } from "../Grid";
 import { useGridPopoverHook } from "../GridPopoverHook";
-import { CellEditorCommon, CellParams } from "../GridCell";
+import { CellEditorCommon } from "../GridCell";
+import { GridPopoverContext } from "../../contexts/GridPopoverContext";
 
 export interface GridFormMessageProps<RowType extends GridBaseRow> extends CellEditorCommon {
-  message: (cellParams: CellParams<RowType>) => Promise<string | JSX.Element> | string | JSX.Element;
+  message: (selectedRows: RowType[]) => Promise<string | JSX.Element> | string | JSX.Element;
 }
 
-export const GridFormMessage = <RowType extends GridBaseRow>(_props: GridFormMessageProps<RowType>) => {
-  const props = _props as GridFormMessageProps<RowType> & CellParams<RowType>;
+export const GridFormMessage = <RowType extends GridBaseRow>(props: GridFormMessageProps<RowType>) => {
+  const { selectedRows } = useContext(GridPopoverContext);
   const [message, setMessage] = useState<string | JSX.Element | null>(null);
   const { popoverWrapper } = useGridPopoverHook({ className: props.className });
 
   useEffect(() => {
     (async () => {
-      setMessage(await props.message(props));
+      setMessage(await props.message(selectedRows));
     })().then();
-  }, [props]);
+  }, [props, selectedRows]);
 
   return popoverWrapper(
     <ComponentLoadingWrapper loading={message === null} className={clsx("GridFormMessage-container", props.className)}>

--- a/src/components/gridForm/GridFormMessage.tsx
+++ b/src/components/gridForm/GridFormMessage.tsx
@@ -12,6 +12,7 @@ export interface GridFormMessageProps<RowType extends GridBaseRow> extends CellE
 
 export const GridFormMessage = <RowType extends GridBaseRow>(props: GridFormMessageProps<RowType>) => {
   const { selectedRows } = useContext(GridPopoverContext);
+
   const [message, setMessage] = useState<string | JSX.Element | null>(null);
   const { popoverWrapper } = useGridPopoverHook({ className: props.className });
 

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -26,7 +26,6 @@ export interface SelectedOptionResult<ValueType> extends MultiFinalSelectOption<
 }
 
 export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType> extends CellEditorCommon {
-  // This overrides CellEditorCommon to provide some common class options
   className?:
     | "GridMultiSelect-containerSmall"
     | "GridMultiSelect-containerMedium"

--- a/src/components/gridForm/GridFormMultiSelect.tsx
+++ b/src/components/gridForm/GridFormMultiSelect.tsx
@@ -1,16 +1,17 @@
 import "../../styles/GridFormMultiSelect.scss";
 
-import { MenuItem, MenuDivider, FocusableItem } from "../../react-menu3";
-import { useCallback, useEffect, useRef, useState, KeyboardEvent, useMemo } from "react";
+import { FocusableItem, MenuDivider, MenuItem } from "../../react-menu3";
+import { KeyboardEvent, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { GridBaseRow } from "../Grid";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
 import { delay, fromPairs, isEqual, omit, pick, toPairs } from "lodash-es";
 import { LuiCheckboxInput } from "@linzjs/lui";
 import { useGridPopoverHook } from "../GridPopoverHook";
 import { MenuSeparatorString } from "./GridFormDropDown";
-import { CellEditorCommon, CellParams } from "../GridCell";
+import { CellEditorCommon } from "../GridCell";
 import { ClickEvent } from "../../react-menu3/types";
 import { GridSubComponentContext } from "contexts/GridSubComponentContext";
+import { GridPopoverContext } from "../../contexts/GridPopoverContext";
 
 interface MultiFinalSelectOption<ValueType> {
   value: ValueType;
@@ -45,7 +46,7 @@ export interface GridFormMultiSelectProps<RowType extends GridBaseRow, ValueType
 export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(
   props: GridFormMultiSelectProps<RowType, ValueType>,
 ) => {
-  const { selectedRows } = props as unknown as CellParams<RowType>;
+  const { selectedRows } = useContext(GridPopoverContext);
 
   const initialiseValues = useMemo(() => {
     const r = props.initialSelectedValues && props.initialSelectedValues(selectedRows);
@@ -90,7 +91,7 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(
       }
       return true;
     },
-    [options, props, selectedValues],
+    [initialiseValues, options, props, selectedValues],
   );
 
   // Load up options list if it's async function
@@ -220,7 +221,10 @@ export const GridFormMultiSelect = <RowType extends GridBaseRow, ValueType>(
                           value={{
                             value: selectedValues[`${item.value}`],
                             setValue: (value: any) => {
-                              setSelectedValues({ ...selectedValues, [`${item.value}`]: value });
+                              setSelectedValues({
+                                ...selectedValues,
+                                [`${item.value}`]: value,
+                              });
                             },
                             setValid: (valid: boolean) => {
                               subComponentIsValid.current[`${item.value}`] = valid;

--- a/src/components/gridForm/GridFormPopoverMenu.tsx
+++ b/src/components/gridForm/GridFormPopoverMenu.tsx
@@ -4,9 +4,10 @@ import { GridContext } from "../../contexts/GridContext";
 import { ComponentLoadingWrapper } from "../ComponentLoadingWrapper";
 import { FocusableItem, MenuDivider, MenuItem } from "../../react-menu3";
 import { useGridPopoverHook } from "../GridPopoverHook";
-import { CellEditorCommon, CellParams } from "../GridCell";
+import { CellEditorCommon } from "../GridCell";
 import { GridSubComponentContext } from "../../contexts/GridSubComponentContext";
 import { ClickEvent } from "../../react-menu3/types";
+import { GridPopoverContext } from "../../contexts/GridPopoverContext";
 
 export interface GridFormPopoutMenuProps<RowType extends GridBaseRow> extends CellEditorCommon {
   options: (selectedRows: RowType[]) => Promise<MenuOption<RowType>[]>;
@@ -36,9 +37,8 @@ export interface MenuOption<RowType extends GridBaseRow> {
  * NOTE: If the popout menu doesn't appear on single click when also selecting row it's because
  * you need a useMemo around your columnDefs
  */
-export const GridFormPopoverMenu = <RowType extends GridBaseRow>(_props: GridFormPopoutMenuProps<RowType>) => {
-  const props = _props as GridFormPopoutMenuProps<RowType> & CellParams<RowType>;
-
+export const GridFormPopoverMenu = <RowType extends GridBaseRow>(props: GridFormPopoutMenuProps<RowType>) => {
+  const { selectedRows, field } = useContext(GridPopoverContext);
   const { updatingCells } = useContext(GridContext);
   const optionsInitialising = useRef(false);
   const [options, setOptions] = useState<MenuOption<RowType>[]>();
@@ -57,26 +57,26 @@ export const GridFormPopoverMenu = <RowType extends GridBaseRow>(_props: GridFor
 
     (async () => {
       if (typeof optionsConf == "function") {
-        setOptions(await optionsConf(props.selectedRows));
+        setOptions(await optionsConf(selectedRows));
       } else {
         setOptions(optionsConf);
       }
 
       optionsInitialising.current = false;
     })();
-  }, [options, props.options, props.selectedRows]);
+  }, [options, props.options, selectedRows]);
 
   const actionClick = useCallback(
     async (menuOption: MenuOption<RowType>) => {
       actionProcessing.current = true;
-      return updatingCells({ selectedRows: props.selectedRows, field: props.field }, async (selectedRows) => {
+      return updatingCells({ selectedRows: selectedRows, field }, async (selectedRows) => {
         const result = { ...menuOption, subValue: subSelectedValue };
         menuOption.action && (await menuOption.action(selectedRows, result));
         actionProcessing.current = false;
         return true;
       });
     },
-    [props.field, props.selectedRows, subSelectedValue, updatingCells],
+    [field, selectedRows, subSelectedValue, updatingCells],
   );
 
   const onMenuItemClick = useCallback(
@@ -96,7 +96,7 @@ export const GridFormPopoverMenu = <RowType extends GridBaseRow>(_props: GridFor
     [actionClick, subComponentSelected],
   );
 
-  const selectedRowCount = props.selectedRows.length;
+  const selectedRowCount = selectedRows.length;
 
   const filteredOptions = options?.filter((menuOption) => {
     return menuOption.label === PopoutMenuSeparator || selectedRowCount === 1 || menuOption.supportsMultiEdit;

--- a/src/components/gridForm/GridFormSubComponentTextInput.tsx
+++ b/src/components/gridForm/GridFormSubComponentTextInput.tsx
@@ -1,6 +1,7 @@
+import "../../styles/GridFormSubComponentTextInput.scss";
+
 import { useState, KeyboardEvent } from "react";
 import { TextInputFormatted } from "../../lui/TextInputFormatted";
-import "../../styles/GridFormSubComponentTextInput.scss";
 
 export interface GridFormSubComponentTextInput {
   setValue: (value: string) => void;

--- a/src/components/gridForm/GridFormTextArea.tsx
+++ b/src/components/gridForm/GridFormTextArea.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { TextAreaInput } from "../../lui/TextAreaInput";
 import { useGridPopoverHook } from "../GridPopoverHook";
 import { GridBaseRow } from "../Grid";
-import { CellEditorCommon, CellParams } from "../GridCell";
+import { CellEditorCommon } from "../GridCell";
+import { GridPopoverContext } from "../../contexts/GridPopoverContext";
 
 export interface GridFormTextAreaProps<RowType extends GridBaseRow> extends CellEditorCommon {
   placeholder?: string;
@@ -13,9 +14,9 @@ export interface GridFormTextAreaProps<RowType extends GridBaseRow> extends Cell
   onSave?: (selectedRows: RowType[], value: string) => Promise<boolean>;
 }
 
-export const GridFormTextArea = <RowType extends GridBaseRow>(_props: GridFormTextAreaProps<RowType>) => {
-  const props = _props as GridFormTextAreaProps<RowType> & CellParams<RowType>;
-  const [value, setValue] = useState(props.value ?? "");
+export const GridFormTextArea = <RowType extends GridBaseRow>(props: GridFormTextAreaProps<RowType>) => {
+  const { field, value: initialVale } = useContext(GridPopoverContext);
+  const [value, setValue] = useState(initialVale ?? "");
 
   const invalid = useCallback(() => {
     if (props.required && value.length == 0) {
@@ -34,13 +35,12 @@ export const GridFormTextArea = <RowType extends GridBaseRow>(_props: GridFormTe
     async (selectedRows: any[]): Promise<boolean> => {
       if (invalid()) return false;
 
-      if (props.value === (value ?? "")) return true;
+      if (initialVale === (value ?? "")) return true;
 
       if (props.onSave) {
         return await props.onSave(selectedRows, value);
       }
 
-      const field = props.field;
       if (field == null) {
         console.error("ColDef has no field set");
         return false;
@@ -48,7 +48,7 @@ export const GridFormTextArea = <RowType extends GridBaseRow>(_props: GridFormTe
       selectedRows.forEach((row) => (row[field] = value));
       return true;
     },
-    [props, invalid, value],
+    [invalid, initialVale, value, props, field],
   );
   const { popoverWrapper } = useGridPopoverHook({ className: props.className, save });
   return popoverWrapper(

--- a/src/components/gridForm/GridFormTextInput.tsx
+++ b/src/components/gridForm/GridFormTextInput.tsx
@@ -18,6 +18,7 @@ export interface GridFormTextInputProps<RowType extends GridBaseRow> extends Cel
 
 export const GridFormTextInput = <RowType extends GridBaseRow>(props: GridFormTextInputProps<RowType>) => {
   const { field, data, value: initialVale } = useContext(GridPopoverContext);
+
   const initValue = initialVale == null ? "" : `${initialVale}`;
   const [value, setValue] = useState(initValue);
 

--- a/src/contexts/GridPopoverContext.tsx
+++ b/src/contexts/GridPopoverContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, RefObject } from "react";
 import { ICellEditorParams } from "ag-grid-community";
+import { GridBaseRow } from "../components/Grid";
 
 export interface PropsType {
   value: any;
@@ -13,14 +14,20 @@ export type GridPopoverContextType = {
   anchorRef: RefObject<Element>;
   saving: boolean;
   setSaving: (saving: boolean) => void;
-  setProps: (props: ICellEditorParams, multiEdit: boolean) => void;
-  propsRef: RefObject<PropsType>;
+  field: string;
+  value: any;
+  data: any;
+  selectedRows: any[];
+  updateValue: (saveFn: (selectedRows: any[]) => Promise<boolean>) => Promise<boolean>;
 };
 
 export const GridPopoverContext = createContext<GridPopoverContextType>({
   anchorRef: { current: null },
   saving: false,
   setSaving: () => {},
-  setProps: () => {},
-  propsRef: { current: null },
+  field: "",
+  value: null,
+  data: null,
+  selectedRows: [],
+  updateValue: async () => false,
 });

--- a/src/contexts/GridPopoverContext.tsx
+++ b/src/contexts/GridPopoverContext.tsx
@@ -1,6 +1,4 @@
 import { createContext, RefObject } from "react";
-import { ICellEditorParams } from "ag-grid-community";
-import { GridBaseRow } from "../components/Grid";
 
 export interface PropsType {
   value: any;

--- a/src/contexts/GridPopoverContextProvider.tsx
+++ b/src/contexts/GridPopoverContextProvider.tsx
@@ -1,5 +1,5 @@
-import { ReactNode, RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { GridPopoverContext, PropsType } from "./GridPopoverContext";
+import { ReactNode, RefObject, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { GridPopoverContext } from "./GridPopoverContext";
 import { ICellEditorParams } from "ag-grid-community";
 import { GridContext } from "./GridContext";
 import { sortBy } from "lodash-es";

--- a/src/react-menu3/contexts/SettingsContext.ts
+++ b/src/react-menu3/contexts/SettingsContext.ts
@@ -1,4 +1,3 @@
-// FIXME hacking a default context in here is probably bad
 import { createContext, MutableRefObject, RefObject } from "react";
 import { ControlledMenuProps, MenuReposition, MenuViewScroll, RectElement, TransitionFieldType } from "../types";
 
@@ -17,4 +16,5 @@ interface SettingsContextType extends ControlledMenuProps {
   viewScroll?: MenuViewScroll;
 }
 
+// FIXME hacking a default context in here is probably bad, but the context is mess
 export const SettingsContext = createContext<SettingsContextType>({} as SettingsContextType);

--- a/src/stories/grid/FormTest.tsx
+++ b/src/stories/grid/FormTest.tsx
@@ -1,11 +1,11 @@
 import "./FormTest.scss";
 
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { LuiAlertModal, LuiAlertModalButtons, LuiButton, LuiTextInput } from "@linzjs/lui";
 import { wait } from "../../utils/util";
-import { CellEditorCommon, CellParams } from "../../components/GridCell";
+import { CellEditorCommon } from "../../components/GridCell";
 import { useGridPopoverHook } from "../../components/GridPopoverHook";
-import { GridBaseRow } from "../../components/Grid";
+import { GridPopoverContext } from "../../contexts/GridPopoverContext";
 
 export interface IFormTestRow {
   id: number;
@@ -16,28 +16,30 @@ export interface IFormTestRow {
   distance: number | null;
 }
 
-export const FormTest = <RowType extends GridBaseRow>(_props: CellEditorCommon): JSX.Element => {
-  const props = _props as CellParams<RowType>;
-  const [v1, ...v2] = props.value.split(" ");
+export const FormTest = (props: CellEditorCommon): JSX.Element => {
+  const { value } = useContext(GridPopoverContext);
+  const [v1, ...v2] = value.split(" ");
 
   const [nameType, setNameType] = useState(v1);
   const [numba, setNumba] = useState(v2.join(" "));
 
-  const save = useCallback(async (): Promise<boolean> => {
-    // eslint-disable-next-line no-console
-    console.log("onSave", props.selectedRows, nameType, numba);
+  const save = useCallback(
+    async (selectedRows: IFormTestRow[]): Promise<boolean> => {
+      // eslint-disable-next-line no-console
+      console.log("onSave", selectedRows, nameType, numba);
 
-    // @ts-ignore
-    props.selectedRows.forEach((row) => (row["name"] = [nameType, numba].join(" ")));
-    await wait(1000);
+      selectedRows.forEach((row) => (row.name = [nameType, numba].join(" ")));
+      await wait(1000);
 
-    // Close form
-    return true;
-  }, [nameType, numba, props.selectedRows]);
+      // Close form
+      return true;
+    },
+    [nameType, numba],
+  );
 
   const [showModal, setShowModal] = useState<boolean>(false);
 
-  const { popoverWrapper } = useGridPopoverHook({ className: _props.className, save });
+  const { popoverWrapper } = useGridPopoverHook({ className: props.className, save });
 
   return popoverWrapper(
     <>

--- a/src/stories/grid/GridPopoutEditMultiSelect.stories.tsx
+++ b/src/stories/grid/GridPopoutEditMultiSelect.stories.tsx
@@ -62,7 +62,7 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
         {
           field: "position",
           initialWidth: 65,
-          maxWidth: 150,
+          maxWidth: 300,
           headerName: "Position",
         },
         {
@@ -105,7 +105,7 @@ const GridEditMultiSelectTemplate: ComponentStory<typeof Grid> = (props: GridPro
           field: "position2",
           initialWidth: 65,
           maxWidth: 150,
-          headerName: "Inital editor values ",
+          headerName: "Initial editor values ",
           valueGetter: (props) => positionTwoMap[props.data.position2],
         },
         {

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -132,7 +132,6 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
                   label: "Other",
                   supportsMultiEdit: true,
                   action: (_, menuOptionResult) => {
-                    console.log(menuOptionResult);
                     alert(`Sub selected value was ${JSON.stringify(menuOptionResult.subValue)}`);
                   },
                   subComponent: () => (

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -86,9 +86,9 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         {
           multiEdit: true,
           editorParams: {
-            message: async (formParams): Promise<string> => {
+            message: async (selectedRows): Promise<string> => {
               await wait(1000);
-              return `There are ${formParams.selectedRows.length} row(s) selected`;
+              return `There are ${selectedRows.length} row(s) selected`;
             },
           },
         },


### PR DESCRIPTION
Old style:
```
const props = _props as GridFormPopoutDropDownProps<RowType, ValueType> & CellParams<RowType>;
const { selectedRows, field, updateValue } = props;
```

Has changed to:
```
  const { selectedRows, field, updateValue } = useContext(GridPopoverContext);
```