### PR TITLE
fix: input buttons excluded from enter to save

### DIFF
--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -125,11 +125,11 @@ export const ControlledMenuFr = (
         return;
       }
 
-      const inputElsIterator = thisDocument.querySelectorAll<HTMLElement>(".szh-menu--state-open input,textarea,button");
+      const inputElsIterator = thisDocument.querySelectorAll<HTMLElement>(".szh-menu--state-open input,textarea");
+      
       let inputEls: HTMLElement[] = [];
       inputElsIterator.forEach((el) => inputEls.push(el));
       inputEls = inputEls.filter((el) => !(el as any).disabled);
-
       if (inputEls.length === 0) return;
       const firstInputEl = inputEls[0];
       const lastInputEl = inputEls[inputEls.length - 1];
@@ -141,10 +141,10 @@ export const ControlledMenuFr = (
         saveButtonRef.current?.setAttribute("data-reason", reason);
         saveButtonRef?.current?.click();
       };
-
+      
       const isTextArea = activeElement.nodeName === "TEXTAREA";
+      const isButton = activeElement.attributes.getNamedItem("type")?.value == "button";
       switch (activeElement.nodeName) {
-        case "BUTTON":
         case "TEXTAREA":
         case "INPUT": {
           if (activeElement === lastInputEl && activeElement === firstInputEl) {
@@ -159,7 +159,7 @@ export const ControlledMenuFr = (
                   invokeSave(ev.shiftKey ? CloseReason.TAB_BACKWARD : CloseReason.TAB_FORWARD);
               }
             }
-            if (ev.key === "Enter" && !isTextArea) {
+            if (ev.key === "Enter" && !isTextArea && !isButton) {
               ev.preventDefault();
               ev.stopPropagation();
               if (isDown) {
@@ -180,7 +180,7 @@ export const ControlledMenuFr = (
                 lastTabDownEl.current == activeElement && invokeSave(CloseReason.TAB_FORWARD);
               }
             }
-            if (ev.key === "Enter" && !isTextArea) {
+            if (ev.key === "Enter" && !isTextArea && !isButton) {
               ev.preventDefault();
               ev.stopPropagation();
               if (isDown) {

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -126,7 +126,7 @@ export const ControlledMenuFr = (
       }
 
       const inputElsIterator = thisDocument.querySelectorAll<HTMLElement>(".szh-menu--state-open input,textarea");
-      
+
       let inputEls: HTMLElement[] = [];
       inputElsIterator.forEach((el) => inputEls.push(el));
       inputEls = inputEls.filter((el) => !(el as any).disabled);
@@ -141,7 +141,7 @@ export const ControlledMenuFr = (
         saveButtonRef.current?.setAttribute("data-reason", reason);
         saveButtonRef?.current?.click();
       };
-      
+
       const isTextArea = activeElement.nodeName === "TEXTAREA";
       const isButton = activeElement.attributes.getNamedItem("type")?.value == "button";
       switch (activeElement.nodeName) {

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -125,7 +125,7 @@ export const ControlledMenuFr = (
         return;
       }
 
-      const inputElsIterator = thisDocument.querySelectorAll<HTMLElement>(".szh-menu--state-open input,textarea");
+      const inputElsIterator = thisDocument.querySelectorAll<HTMLElement>(".szh-menu--state-open input,textarea,button");
       let inputEls: HTMLElement[] = [];
       inputElsIterator.forEach((el) => inputEls.push(el));
       inputEls = inputEls.filter((el) => !(el as any).disabled);
@@ -144,6 +144,7 @@ export const ControlledMenuFr = (
 
       const isTextArea = activeElement.nodeName === "TEXTAREA";
       switch (activeElement.nodeName) {
+        case "BUTTON":
         case "TEXTAREA":
         case "INPUT": {
           if (activeElement === lastInputEl && activeElement === firstInputEl) {
@@ -221,8 +222,8 @@ export const ControlledMenuFr = (
       thisDocument.addEventListener("click", handleScreenEventForCancel, true);
       thisDocument.addEventListener("dblclick", handleScreenEventForCancel, true);
       return () => {
-        thisDocument.addEventListener("keydown", handleKeydownTabAndEnter, true);
-        thisDocument.addEventListener("keyup", handleKeyupTabAndEnter, true);
+        thisDocument.removeEventListener("keydown", handleKeydownTabAndEnter, true);
+        thisDocument.removeEventListener("keyup", handleKeyupTabAndEnter, true);
         thisDocument.removeEventListener("mousedown", handleScreenEventForSave, true);
         thisDocument.removeEventListener("mouseup", handleScreenEventForCancel, true);
         thisDocument.removeEventListener("click", handleScreenEventForCancel, true);

--- a/src/stories/grid/FormTest.tsx
+++ b/src/stories/grid/FormTest.tsx
@@ -98,9 +98,7 @@ export const FormTest = (props: CellEditorCommon): JSX.Element => {
             <LuiTextInput label={"Number"} value={numba} onChange={(e) => setNumba(e.target.value)} />
           </div>
           <div style={{ marginTop: 25 }}>
-            <LuiButton style={{ height: 48 }} onClick={() => setShowModal(true)}>
-              Show Modal
-            </LuiButton>
+            <input type="button" style={{ height: 48 }} onClick={() => setShowModal(true)} value="Show Modal" />
           </div>
         </div>
         <FormError error={invalid()} />


### PR DESCRIPTION
Some editors (like Mark Name) use input buttons for opening a submenu. Enter is required to 'click' them so they need to be excluded from those keyboard handling events like TextAreas are.

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
