### PR TITLE
fix: suppress unwanted grid keyboard events, [Empty] is now _No options_ in dropdown

### DIFF
--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -71,7 +71,7 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
     suppressKeyboardEvent: (e) => {
       // It's important that aggrid doesn't trigger edit on enter
       // as the incorrect selected rows will be returned
-      return !["ArrowLeft", "ArrowRight", "ArrowDown", "ArrowUp", "Tab", "Space"].includes(e.event.key);
+      return !["ArrowLeft", "ArrowRight", "ArrowDown", "ArrowUp", "Tab", " "].includes(e.event.key);
     },
     ...(custom?.editorParams && {
       cellEditorParams: { ...custom.editorParams, multiEdit: custom.multiEdit },

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -71,7 +71,7 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
     suppressKeyboardEvent: (e) => {
       // It's important that aggrid doesn't trigger edit on enter
       // as the incorrect selected rows will be returned
-      return e.event.key === "Enter";
+      return !["ArrowLeft", "ArrowRight", "ArrowDown", "ArrowUp", "Tab", "Space"].includes(e.event.key);
     },
     ...(custom?.editorParams && {
       cellEditorParams: { ...custom.editorParams, multiEdit: custom.multiEdit },

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -224,8 +224,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow>(props: GridFormPop
               <div style={{ display: "flex", width: "100%" }}>
                 <input
                   autoFocus
-                  className={"free-text-input"}
-                  style={{ border: "0px" }}
+                  className={"LuiTextInput-input"}
                   ref={ref}
                   type="text"
                   placeholder={props.filterPlaceholder ?? "Placeholder"}
@@ -242,7 +241,9 @@ export const GridFormDropDown = <RowType extends GridBaseRow>(props: GridFormPop
       <ComponentLoadingWrapper loading={!options} className={"GridFormDropDown-options"}>
         <>
           {options && options.length == filteredValues?.length && (
-            <MenuItem key={`${fieldToString(field)}-empty`}>[Empty]</MenuItem>
+            <MenuItem key={`${fieldToString(field)}-empty`} className={"GridPopoverEditDropDown-noOptions"}>
+              No Options
+            </MenuItem>
           )}
           {options?.map((item: FinalSelectOption, index) =>
             item.value === MenuSeparatorString ? (

--- a/src/styles/GridFormDropDown.scss
+++ b/src/styles/GridFormDropDown.scss
@@ -16,3 +16,7 @@
 .GridPopoverEditDropDown-containerUnlimited .GridFormDropDown-options {
   overflow-y: auto;
 }
+
+.GridPopoverEditDropDown-noOptions {
+  justify-content: center;
+}


### PR DESCRIPTION
fix: suppress unwanted grid keyboard events, [Empty] is now _No options_ in dropdown