### PR TITLE
fix: blank render cells

### DIFF
--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -102,9 +102,18 @@ export interface CellEditorCommon {
 
 export const GenericCellEditorComponentWrapper = (custom?: { editor?: (props: any) => JSX.Element }) => {
   return forwardRef(function GenericCellEditorComponentFr(cellEditorParams: ICellEditorParams, _) {
+    const valueFormatted = cellEditorParams.formatValue
+      ? cellEditorParams.formatValue(cellEditorParams.value)
+      : "Missing formatter";
     return (
       <GridPopoverContextProvider props={cellEditorParams}>
-        {<cellEditorParams.colDef.cellRenderer {...cellEditorParams} {...cellEditorParams.colDef.cellRendererParams} />}
+        {
+          <cellEditorParams.colDef.cellRenderer
+            {...cellEditorParams}
+            valueFormatted={valueFormatted}
+            {...cellEditorParams.colDef.cellRendererParams}
+          />
+        }
         {custom?.editor && <custom.editor {...cellEditorParams} />}
       </GridPopoverContextProvider>
     );

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -63,8 +63,3 @@
 .Grid-container.ag-theme-alpine .ag-cell-wrapper {
   width: 100%;
 }
-
-.Grid-container.ag-theme-alpine .ag-cell-inline-editing {
-  padding-left: 5px;
-  padding-right: 2px;
-}

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -24,6 +24,7 @@
       border-color: lui.$lily,
       secondary-border-color: lui.$lily,
       cell-horizontal-border: solid ag-derived(secondary-border-color),
+      cell-horizontal-padding: 12,
       row-hover-color: lui.$lily,
       font-family: (
         "Open Sans",
@@ -59,7 +60,7 @@
 
   .ag-header-cell {
     font-weight: 600;
-    padding: 7px 0 7px 8px;
+    padding: 7px 11px;
 
     .LuiIcon {
       fill: lui.$surfie;
@@ -67,16 +68,16 @@
   }
 
   .ag-cell {
-    padding-left: 7px;
-    padding-right: 4px;
+    padding-left: 11px;
+    padding-right: 11px;
     display: flex;
     align-items: center;
   }
 
-  .ag-cell-more {
-    padding: 0;
-    display: flex;
-    justify-content: center;
+  .ag-cell.ag-cell-inline-editing {
+    padding-left: 9px;
+    padding-right: 9px;
+    bottom: 0;
   }
 
   .ag-cell-wrap-text {


### PR DESCRIPTION
Due to cellEditorParams not having a formatted value which is passed to the renderer component