### PR TITLE
fix: Use original Bearing correction format

### DIFF
--- a/src/stories/grid/GridPopoutBearing.stories.tsx
+++ b/src/stories/grid/GridPopoutBearing.stories.tsx
@@ -89,6 +89,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
     { id: 1002, bearing: null, bearingCorrection: 355.1 },
     { id: 1003, bearing: null, bearingCorrection: 0 },
     { id: 1004, bearing: 5.0, bearingCorrection: "1.00500" },
+    { id: 1001, bearing: null, bearingCorrection: "0E-12" },
   ] as ITestRow[]);
 
   return (

--- a/src/stories/grid/GridPopoutBearing.stories.tsx
+++ b/src/stories/grid/GridPopoutBearing.stories.tsx
@@ -89,7 +89,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
     { id: 1002, bearing: null, bearingCorrection: 355.1 },
     { id: 1003, bearing: null, bearingCorrection: 0 },
     { id: 1004, bearing: 5.0, bearingCorrection: "1.00500" },
-    { id: 1001, bearing: null, bearingCorrection: "0E-12" },
+    { id: 1005, bearing: null, bearingCorrection: "0E-12" },
   ] as ITestRow[]);
 
   return (

--- a/src/utils/bearing.ts
+++ b/src/utils/bearing.ts
@@ -14,9 +14,9 @@ export const bearingCorrectionValueFormatter = (params: ValueFormatterParams): s
     return "–";
   }
   if (typeof value === "string") {
-    return convertDDToDMS(bearingNumberParser(value), true, false);
+    return convertDDToDMS(bearingNumberParser(value), true, true);
   }
-  return convertDDToDMS(value, true, false);
+  return convertDDToDMS(value, true, true);
 };
 
 export const bearingNumberParser = (value: string): number | null => {


### PR DESCRIPTION
Show `+1 00' 00"` instead `+1 00'` in Bearing correction

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
