### PR TITLE
fix: bearing regex validation message does not refer to positive numbers

### DIFF
--- a/src/utils/bearing.ts
+++ b/src/utils/bearing.ts
@@ -32,7 +32,7 @@ export const bearingStringValidator = (
   value = value.trim();
   if (value === "") return null;
   const match = value.match(validMaskForDmsBearing);
-  if (!match) return "Bearing must be a positive number in D.MMSSS format";
+  if (!match) return "Bearing must be a number in D.MMSSS format";
   const decimalPart = match[4];
   if (decimalPart != null && decimalPart.length > 5) {
     return "Bearing has a maximum of 5 decimal places";


### PR DESCRIPTION
The validation message for the default regex check for bearings referred to positive numbers exclusively. In some situations negative bearings are allowed and the regex actually allows for this. The message has been tweaked so it doesn't refer to positive numbers only.

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
