### PR TITLE
fix: dont focus cell if currently editing

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -186,9 +186,9 @@ export const Grid = (params: GridProps): JSX.Element => {
                 } else {
                   e.api.deselectAll();
                 }
-                return false;
+                return true;
               }
-              return true;
+              return false;
             },
             onCellClicked: clickSelectorCheckboxWhenContainingCellClicked,
           },

--- a/src/components/gridHeader/GridHeaderSelect.tsx
+++ b/src/components/gridHeader/GridHeaderSelect.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { IHeaderParams } from "ag-grid-community";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * AgGrid's existing select header doesn't work the way we want.
@@ -12,9 +12,9 @@ export const GridHeaderSelect = ({ api }: IHeaderParams) => {
   const [updateCounter, setUpdateCounter] = useState(0);
   const selectedNodeCount = api.getSelectedRows().length;
 
-  const clickHandler = () => {
+  const clickHandler = useCallback(() => {
     setUpdateCounter(updateCounter + 1);
-  };
+  }, [updateCounter]);
 
   useEffect(() => {
     api.addEventListener("selectionChanged", clickHandler);

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode, useContext, useRef, useState } from "react";
 import { ColDef, GridApi, RowNode } from "ag-grid-community";
 import { GridContext } from "./GridContext";
-import { delay, difference, isEmpty, last, sortBy } from "lodash-es";
+import { defer, delay, difference, isEmpty, last, sortBy } from "lodash-es";
 import { isNotEmpty, wait } from "../utils/util";
 import { GridUpdatingContext } from "./GridUpdatingContext";
 import { GridBaseRow } from "../components/Grid";
@@ -139,7 +139,9 @@ export const GridContextProvider = (props: GridContextProps): ReactElement => {
           const rowIndex = firstNode.rowIndex;
           if (rowIndex != null && col != null) {
             const colId = col.colId;
-            colId != null && setTimeout(() => gridApi.setFocusedCell(rowIndex, colId), 100);
+            // We need to make sure we aren't currently editing a cell otherwise tests will fail
+            // as they will start to edit the cell before this stuff has a chance to run
+            colId != null && defer(() => isEmpty(gridApi.getEditingCells()) && gridApi.setFocusedCell(rowIndex, colId));
           }
         }
       }


### PR DESCRIPTION
Otherwise tests start editing before focus can run, and setting focus cancels edit.