### PR TITLE
feat: expose Grid interface to notify client when a column has been m…

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { AgGridReact } from "ag-grid-react";
 import { CellClickedEvent, ColDef } from "ag-grid-community";
-import { CellEvent, GridReadyEvent, SelectionChangedEvent } from "ag-grid-community/dist/lib/events";
+import { CellEvent, ColumnMovedEvent, GridReadyEvent, SelectionChangedEvent } from "ag-grid-community/dist/lib/events";
 import { GridOptions } from "ag-grid-community/dist/lib/entities/gridOptions";
 import { difference, isEmpty, last, xorBy } from "lodash-es";
 import { GridContext } from "../contexts/GridContext";
@@ -35,6 +35,7 @@ export interface GridProps {
   rowClassRules?: GridOptions["rowClassRules"];
   rowSelection?: "single" | "multiple";
   autoSelectFirstRow?: boolean;
+  onColumnMoved?: (event: ColumnMovedEvent) => void;
 }
 
 /**
@@ -339,6 +340,7 @@ export const Grid = (params: GridProps): JSX.Element => {
         onSortChanged={ensureSelectedRowIsVisible}
         postSortRows={params.postSortRows ?? postSortRows}
         onSelectionChanged={synchroniseExternalStateToGridSelection}
+        onColumnMoved={params.onColumnMoved || undefined}
       />
     </div>
   );

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { AgGridReact } from "ag-grid-react";
 import { CellClickedEvent, ColDef } from "ag-grid-community";
-import { CellEvent, ColumnMovedEvent, GridReadyEvent, SelectionChangedEvent } from "ag-grid-community/dist/lib/events";
+import { CellEvent, GridReadyEvent, SelectionChangedEvent } from "ag-grid-community/dist/lib/events";
 import { GridOptions } from "ag-grid-community/dist/lib/entities/gridOptions";
 import { difference, isEmpty, last, xorBy } from "lodash-es";
 import { GridContext } from "../contexts/GridContext";
@@ -35,7 +35,7 @@ export interface GridProps {
   rowClassRules?: GridOptions["rowClassRules"];
   rowSelection?: "single" | "multiple";
   autoSelectFirstRow?: boolean;
-  onColumnMoved?: (event: ColumnMovedEvent) => void;
+  onColumnMoved?: GridOptions["onColumnMoved"];
 }
 
 /**
@@ -340,7 +340,7 @@ export const Grid = (params: GridProps): JSX.Element => {
         onSortChanged={ensureSelectedRowIsVisible}
         postSortRows={params.postSortRows ?? postSortRows}
         onSelectionChanged={synchroniseExternalStateToGridSelection}
-        onColumnMoved={params.onColumnMoved || undefined}
+        onColumnMoved={params.onColumnMoved}
       />
     </div>
   );


### PR DESCRIPTION
feat: [TITLE-4418](https://toitutewhenua.atlassian.net/browse/TITLE-4418) requires us to persist column orders (relative positions) across user sessions. An interface on `Grid` component needs to be exposed in order to notify the client code when a column has been moved, so the client can persist the new column orders.

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
