### PR TITLE
feat: added test function for validating menu options

### DIFF
--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -1,6 +1,7 @@
 import { act, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { findQuick, getAllQuick, getMatcher, getQuick, queryQuick } from "./testQuick";
+import { isEqual } from "lodash-es";
 
 export const countRows = async (within?: HTMLElement): Promise<number> => {
   return getAllQuick({ tagName: `div[row-id]:not(:empty)` }, within).length;
@@ -96,6 +97,12 @@ export const findMenuOption = async (menuOptionText: string | RegExp): Promise<H
     },
     { timeout: 5000 },
   );
+};
+
+export const validateMenuOptions = async (expectedMenuOptions: Array<string>): Promise<boolean> => {
+  const openMenu = await findOpenMenu();
+  const actualOptions = (await within(openMenu).findAllByRole("menuitem")).map((menuItem) => menuItem.textContent);
+  return isEqual(actualOptions, expectedMenuOptions);
 };
 
 export const clickMenuOption = async (menuOptionText: string | RegExp): Promise<void> => {

--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -99,7 +99,12 @@ export const findMenuOption = async (menuOptionText: string | RegExp): Promise<H
   );
 };
 
-export const validateMenuOptions = async (expectedMenuOptions: Array<string>): Promise<boolean> => {
+export const validateMenuOptions = async (
+  rowId: number | string,
+  colId: string,
+  expectedMenuOptions: Array<string>,
+): Promise<boolean> => {
+  await editCell(rowId, colId);
   const openMenu = await findOpenMenu();
   const actualOptions = (await within(openMenu).findAllByRole("menuitem")).map((menuItem) => menuItem.textContent);
   return isEqual(actualOptions, expectedMenuOptions);


### PR DESCRIPTION
A few of the existing tests validate the menu options for an editor by passing in an array of values. This PR adds a function to do this with the step-ag-grid to replace the existing functions that use the old grid querying code.

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
