### PR TITLE
fix: minwidth on action menu

### DIFF
--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -13,7 +13,9 @@ export const GridPopoverMenu = <RowType extends GridBaseRow>(
 ): ColDefT<RowType> =>
   GridCell<RowType, GridFormPopoutMenuProps<RowType>>(
     {
+      minWidth: 40,
       maxWidth: 40,
+      width: 40,
       editable: colDef.editable != null ? colDef.editable : true,
       cellStyle: { justifyContent: "center" },
       cellRenderer: GridRenderPopoutMenuCell,


### PR DESCRIPTION
If min width is not set action menu icon dissapears.