### PR TITLE
fix: popup menu not closing on action after invalid subcomponent, cell edit stop steals focus

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -297,16 +297,6 @@ export const Grid = (params: GridProps): JSX.Element => {
     [startCellEditing],
   );
 
-  const onCellEditingStopped = useCallback(
-    (event: CellEvent) => {
-      refreshSelectedRows(event);
-      // The grid loses cell focus after editing
-      const cell = event.api.getFocusedCell();
-      cell && event.api.setFocusedCell(cell.rowIndex, cell.column);
-    },
-    [refreshSelectedRows],
-  );
-
   // When rows added or removed then resize columns
   useEffect(() => {
     if (columnDefs?.length) {
@@ -354,7 +344,6 @@ export const Grid = (params: GridProps): JSX.Element => {
         onCellClicked={onCellClicked}
         onCellDoubleClicked={onCellDoubleClick}
         onCellEditingStarted={refreshSelectedRows}
-        onCellEditingStopped={onCellEditingStopped}
         domLayout={params.domLayout}
         columnDefs={columnDefs}
         rowData={params.rowData}

--- a/src/components/gridForm/GridFormPopoverMenu.tsx
+++ b/src/components/gridForm/GridFormPopoverMenu.tsx
@@ -95,6 +95,8 @@ export const GridFormPopoverMenu = <RowType extends GridBaseRow>(props: GridForm
         setSubComponentSelected(subComponentSelected === item ? null : item);
         e.keepOpen = true;
       } else {
+        subComponentIsValid.current = true;
+        setSubSelectedValue(null);
         await updateValue(async () => actionClick(item), e.key === "Tab" ? (e.shiftKey ? -1 : 1) : 0);
       }
     },

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -120,6 +120,10 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         {
           multiEdit: true,
           editorParams: {
+            defaultAction: async ({ menuOption }) => {
+              // eslint-disable-next-line no-console
+              console.log("clicked", { menuOption });
+            },
             options: async (selectedItems) => {
               // Just doing a timeout here to demonstrate deferred loading
               await wait(500);

--- a/src/stories/grid/gridForm/GridFormMultiSelect.stories.tsx
+++ b/src/stories/grid/gridForm/GridFormMultiSelect.stories.tsx
@@ -22,7 +22,7 @@ const Template: ComponentStory<typeof GridFormMultiSelect> = (props) => {
       "With options",
       {
         options: [
-          { label: "One", value: 0 },
+          { label: "One", value: 0, checked: true },
           { label: "Two", value: 1 },
         ],
       },
@@ -34,7 +34,7 @@ const Template: ComponentStory<typeof GridFormMultiSelect> = (props) => {
         options: [
           { label: "One", value: 0 },
           { label: "With warning", value: 1, warning: "Test warning" },
-          { label: "Three", value: 2 },
+          { label: "Three", value: 2, checked: true },
         ],
       },
     ],


### PR DESCRIPTION
fix: popup menu not closing on action after invalid subcomponent
fix: cell edit stop steals focus from popup dialog
