### PR TITLE
fix: make aggrid 28 header same as 27

### DIFF
--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -71,3 +71,7 @@
 .Grid-container.ag-theme-alpine .ag-cell-wrapper {
   width: 100%;
 }
+
+.Grid-container.ag-theme-alpine  ag-cell-label-container {
+  padding: 0;
+}


### PR DESCRIPTION
Slight padding change such that headers are visiually the same