### PR TITLE
BREAKING CHANGE: Revert to v27 aggrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@linzjs/lui": ">=17",
-        "ag-grid-community": "^28.2.1",
-        "ag-grid-react": "^28.2.1",
+        "ag-grid-community": "27.3.0",
+        "ag-grid-react": "^27.3.0",
         "debounce-promise": "^3.1.2",
         "lodash-es": ">=4",
         "matcher": "^5.0.0",
@@ -15678,19 +15678,19 @@
       }
     },
     "node_modules/ag-grid-community": {
-      "version": "28.2.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-28.2.1.tgz",
-      "integrity": "sha512-DMZh/xD/FqYP17qJ1M92PolTYe+hrKuEaf+A4h13O6qn2x/xZQrTRGW5DgnQLR/uLMe1XXZQPKR3UKgAlKo69A=="
+      "version": "27.3.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-27.3.0.tgz",
+      "integrity": "sha512-R5oZMXEHXnOLrmhn91J8lR0bv6IAnRcU6maO+wKLMJxffRWaAYFAuw1jt7bdmcKCv8c65F6LEBx4ykSOALa9vA=="
     },
     "node_modules/ag-grid-react": {
-      "version": "28.2.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-28.2.1.tgz",
-      "integrity": "sha512-3vbw+B77uWwAyiOJxQA5U+PQFRCCccUx7L5PIwrnA4Y7c1yAu8sB65hAZdBc9kuW26iltwv7asq0UzP7UAQUpg==",
+      "version": "27.3.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-27.3.0.tgz",
+      "integrity": "sha512-2bs9YfJ/shvBZQLLjny4NFvht+ic6VtpTPO0r3bHHOhlL3Fjx2rGvS6AHSwfvu+kJacHCta30PjaEbX8T3UDyw==",
       "dependencies": {
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "ag-grid-community": "~28.2.1",
+        "ag-grid-community": "~27.3.0",
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "@linzjs/lui": ">=17",
-    "ag-grid-community": "^28.2.1",
-    "ag-grid-react": "^28.2.1",
+    "ag-grid-community": "^27.3.0",
+    "ag-grid-react": "^27.3.0",
     "debounce-promise": "^3.1.2",
     "lodash-es": ">=4",
     "matcher": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@linzjs/lui": ">=17",
-    "ag-grid-community": "^27.3.0",
+    "ag-grid-community": "27.3.0",
     "ag-grid-react": "^27.3.0",
     "debounce-promise": "^3.1.2",
     "lodash-es": ">=4",

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -316,11 +316,6 @@ export const Grid = (params: GridProps): JSX.Element => {
     }
   }, [columnDefs?.length, sizeColumnsToFit]);
 
-  const defaultColDef = useMemo(
-    () => ({ wrapHeaderText: true, autoHeaderHeight: true, ...params.defaultColDef }),
-    [params.defaultColDef],
-  );
-
   return (
     <div
       data-testid={params["data-testid"]}
@@ -349,7 +344,6 @@ export const Grid = (params: GridProps): JSX.Element => {
         <AgGridReact
           animateRows={params.animateRows}
           rowClassRules={params.rowClassRules}
-          defaultColDef={defaultColDef}
           getRowId={(params) => `${params.data.id}`}
           suppressRowClickSelection={true}
           rowSelection={params.rowSelection ?? "multiple"}

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -134,7 +134,7 @@ export const ControlledMenuFr = (
       };
 
       const allowTabToSave = activeElement.getAttribute("data-allowtabtosave") == "true";
-      if (allowTabToSave) {
+      if (allowTabToSave && ev.key === "Tab") {
         if (isDown) {
           ev.preventDefault();
           ev.stopPropagation();

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -71,7 +71,3 @@
 .Grid-container.ag-theme-alpine .ag-cell-wrapper {
   width: 100%;
 }
-
-.Grid-container.ag-theme-alpine  ag-cell-label-container {
-  padding: 0;
-}

--- a/src/utils/textValidator.test.ts
+++ b/src/utils/textValidator.test.ts
@@ -73,6 +73,10 @@ describe("TextInputValidator", () => {
         tests: [
           ["xx", null],
           ["", "Must not be empty"],
+          ["\t", "Must not be empty"],
+          ["\n", "Must not be empty"],
+          ["\r", "Must not be empty"],
+          [" ", "Must not be empty"],
         ],
       },
     ] as (TextInputValidatorProps<GridBaseRow> & { tests: [string, string | undefined][] })[];

--- a/src/utils/textValidator.ts
+++ b/src/utils/textValidator.ts
@@ -28,7 +28,7 @@ export const TextInputValidator = <RowType extends GridBaseRow>(
   if (typeof value !== "string") {
     return "Value is not a string";
   }
-  if (props.required && value == "") {
+  if (props.required && value.trim() == "") {
     return "Must not be empty";
   }
   if (props.maxLength && value.length > props.maxLength) {


### PR DESCRIPTION
Aggrid 28 breaks tests due to a jsdom bug focusin event bug, so this reverts to v27.
Also fix enter to save not working in multiselect.

BREAKING CHANGE: Revert to v27 aggrid