### PR TITLE
External grid filters

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -222,11 +222,12 @@ export const Grid = (params: GridProps): JSX.Element => {
         ]
       : adjustColDefs;
   }, [
-    clickSelectorCheckboxWhenContainingCellClicked,
     params.columnDefs,
     params.selectable,
+    params.rowSelection,
     params.readOnly,
-    params.defaultColDef,
+    params.defaultColDef?.editable,
+    clickSelectorCheckboxWhenContainingCellClicked,
   ]);
 
   const onGridReady = useCallback(

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -223,6 +223,10 @@ export const Grid = (params: GridProps): JSX.Element => {
     [params.rowData?.length],
   );
 
+  const onModelUpdated = useCallback((event: ModelUpdatedEvent) => {
+    event.api.getDisplayedRowCount() === 0 ? event.api.showNoRowsOverlay() : event.api.hideOverlay();
+  }, []);
+
   const refreshSelectedRows = useCallback((event: CellEvent): void => {
     // Force-refresh all selected rows to re-run class function, to update selection highlighting
     event.api.refreshCells({
@@ -328,6 +332,7 @@ export const Grid = (params: GridProps): JSX.Element => {
           columnDefs={columnDefs}
           rowData={params.rowData}
           noRowsOverlayComponent={noRowsOverlayComponent}
+          onModelUpdated={onModelUpdated}
           onGridReady={onGridReady}
           onSortChanged={ensureSelectedRowIsVisible}
           postSortRows={params.postSortRows ?? postSortRows}
@@ -336,9 +341,6 @@ export const Grid = (params: GridProps): JSX.Element => {
           alwaysShowVerticalScroll={params.alwaysShowVerticalScroll}
           isExternalFilterPresent={isExternalFilterPresent}
           doesExternalFilterPass={doesExternalFilterPass}
-          onModelUpdated={(event: ModelUpdatedEvent) => {
-            event.api.getDisplayedRowCount() === 0 ? event.api.showNoRowsOverlay() : event.api.hideOverlay();
-          }}
         />
       </div>
     </div>

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -55,6 +55,8 @@ export const Grid = (params: GridProps): JSX.Element => {
     sizeColumnsToFit,
     externallySelectedItemsAreInSync,
     setExternallySelectedItemsAreInSync,
+    isExternalFilterPresent,
+    doesExternalFilterPass,
   } = useContext(GridContext);
   const { checkUpdating } = useContext(GridUpdatingContext);
 
@@ -366,6 +368,8 @@ export const Grid = (params: GridProps): JSX.Element => {
           onSelectionChanged={synchroniseExternalStateToGridSelection}
           onColumnMoved={params.onColumnMoved}
           alwaysShowVerticalScroll={params.alwaysShowVerticalScroll}
+          isExternalFilterPresent={isExternalFilterPresent}
+          doesExternalFilterPass={doesExternalFilterPass}
         />
       </div>
     </div>

--- a/src/components/GridFilter.ts
+++ b/src/components/GridFilter.ts
@@ -1,9 +1,8 @@
-import { useEffect } from "react";
-import { GridFilterExternal, useGridContext } from "../contexts/GridContext";
-import { GridBaseRow } from "./Grid";
+import { useContext, useEffect } from "react";
+import { GridContext, GridFilterExternal } from "../contexts/GridContext";
 
-export const useGridFilter = <RowType extends GridBaseRow>(filter: GridFilterExternal<RowType>) => {
-  const { addExternalFilter, removeExternalFilter } = useGridContext<RowType>();
+export const useGridFilter = (filter: GridFilterExternal) => {
+  const { addExternalFilter, removeExternalFilter } = useContext(GridContext);
 
   useEffect(() => {
     const thisFilter = filter;

--- a/src/components/GridFilter.ts
+++ b/src/components/GridFilter.ts
@@ -1,0 +1,13 @@
+import { useContext, useEffect } from "react";
+import { GridContext, GridFilterExternal } from "../contexts/GridContext";
+import { GridBaseRow } from "./Grid";
+
+export const useGridFilter = <RowType extends GridBaseRow>(filter: GridFilterExternal<RowType>) => {
+  const { addExternalFilter, removeExternalFilter } = useContext(GridContext);
+
+  useEffect(() => {
+    const thisFilter = filter;
+    addExternalFilter(thisFilter);
+    return () => removeExternalFilter(thisFilter);
+  }, [addExternalFilter, filter, removeExternalFilter]);
+};

--- a/src/components/GridFilter.ts
+++ b/src/components/GridFilter.ts
@@ -1,9 +1,9 @@
-import { useContext, useEffect } from "react";
-import { GridContext, GridFilterExternal } from "../contexts/GridContext";
+import { useEffect } from "react";
+import { GridFilterExternal, useGridContext } from "../contexts/GridContext";
 import { GridBaseRow } from "./Grid";
 
 export const useGridFilter = <RowType extends GridBaseRow>(filter: GridFilterExternal<RowType>) => {
-  const { addExternalFilter, removeExternalFilter } = useContext(GridContext);
+  const { addExternalFilter, removeExternalFilter } = useGridContext<RowType>();
 
   useEffect(() => {
     const thisFilter = filter;

--- a/src/components/GridWrapper.tsx
+++ b/src/components/GridWrapper.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+
+export interface GridWrapperProps {
+  children: ReactNode;
+  maxHeight?: number | string;
+}
+
+export const GridWrapper = ({ children, maxHeight }: GridWrapperProps) => (
+  <div className={"Grid-wrapper"} style={{ maxHeight }}>
+    {children}
+  </div>
+);

--- a/src/components/gridFilter/GridFilterQuick.tsx
+++ b/src/components/gridFilter/GridFilterQuick.tsx
@@ -1,0 +1,29 @@
+import { useContext, useEffect, useState } from "react";
+import { GridContext } from "../../contexts/GridContext";
+
+export interface GridFilterQuickProps {
+  quickFilterPlaceholder?: string;
+  defaultValue?: string;
+}
+
+export const GridFilterQuick = ({ quickFilterPlaceholder, defaultValue }: GridFilterQuickProps) => {
+  const { setQuickFilter } = useContext(GridContext);
+  const [quickFilterValue, setQuickFilterValue] = useState(defaultValue ?? "");
+
+  useEffect(() => {
+    setQuickFilter(quickFilterValue);
+  }, [quickFilterValue, setQuickFilter]);
+
+  return (
+    <input
+      aria-label="Search"
+      className="lui-margin-top-xxs lui-margin-bottom-xxs Grid-quickFilterBox"
+      type="text"
+      placeholder={quickFilterPlaceholder ?? "Search..."}
+      value={quickFilterValue}
+      onChange={(event): void => {
+        setQuickFilterValue(event.target.value);
+      }}
+    />
+  );
+};

--- a/src/components/gridFilter/GridFilters.tsx
+++ b/src/components/gridFilter/GridFilters.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+export interface GridFiltersProps {
+  children: ReactNode;
+}
+
+export const GridFilters = ({ children }: GridFiltersProps) => <div className="Grid-container-filters">{children}</div>;

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -1,8 +1,10 @@
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 import { GridApi, RowNode } from "ag-grid-community";
 import { GridBaseRow } from "../components/Grid";
 
-export interface GridContextType {
+export type GridFilterExternal<RowType extends GridBaseRow> = (data: RowType, rowNode: RowNode) => boolean;
+
+export interface GridContextType<RowType extends GridBaseRow> {
   gridReady: boolean;
   setGridApi: (gridApi: GridApi | undefined) => void;
   prePopupOps: () => void;
@@ -31,9 +33,13 @@ export interface GridContextType {
   externallySelectedItemsAreInSync: boolean;
   setExternallySelectedItemsAreInSync: (inSync: boolean) => void;
   waitForExternallySelectedItemsToBeInSync: () => Promise<void>;
+  addExternalFilter: (filter: GridFilterExternal<RowType>) => void;
+  removeExternalFilter: (filter: GridFilterExternal<RowType>) => void;
+  isExternalFilterPresent: () => boolean;
+  doesExternalFilterPass: (node: RowNode) => boolean;
 }
 
-export const GridContext = createContext<GridContextType>({
+export const GridContext = createContext<GridContextType<any>>({
   gridReady: false,
   prePopupOps: () => {
     console.error("no context provider for prePopupOps");
@@ -104,4 +110,20 @@ export const GridContext = createContext<GridContextType>({
   waitForExternallySelectedItemsToBeInSync: async () => {
     console.error("no context provider for waitForExternallySelectedItemsToBeInSync");
   },
+  addExternalFilter: () => {
+    console.error("no context provider for addExternalFilter");
+  },
+  removeExternalFilter: () => {
+    console.error("no context provider for removeExternalFilter");
+  },
+  isExternalFilterPresent: () => {
+    console.error("no context provider for isExternalFilterPresent");
+    return false;
+  },
+  doesExternalFilterPass: () => {
+    console.error("no context provider for doesExternalFilterPass");
+    return true;
+  },
 });
+
+export const useGridContext = <RowType extends GridBaseRow>() => useContext<GridContextType<RowType>>(GridContext);

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -1,10 +1,10 @@
-import { createContext, useContext } from "react";
+import { createContext } from "react";
 import { GridApi, RowNode } from "ag-grid-community";
 import { GridBaseRow } from "../components/Grid";
 
-export type GridFilterExternal<RowType extends GridBaseRow> = (data: RowType, rowNode: RowNode) => boolean;
+export type GridFilterExternal = (data: any, rowNode: RowNode) => boolean;
 
-export interface GridContextType<RowType extends GridBaseRow> {
+export interface GridContextType {
   gridReady: boolean;
   setGridApi: (gridApi: GridApi | undefined) => void;
   prePopupOps: () => void;
@@ -33,13 +33,13 @@ export interface GridContextType<RowType extends GridBaseRow> {
   externallySelectedItemsAreInSync: boolean;
   setExternallySelectedItemsAreInSync: (inSync: boolean) => void;
   waitForExternallySelectedItemsToBeInSync: () => Promise<void>;
-  addExternalFilter: (filter: GridFilterExternal<RowType>) => void;
-  removeExternalFilter: (filter: GridFilterExternal<RowType>) => void;
+  addExternalFilter: (filter: GridFilterExternal) => void;
+  removeExternalFilter: (filter: GridFilterExternal) => void;
   isExternalFilterPresent: () => boolean;
   doesExternalFilterPass: (node: RowNode) => boolean;
 }
 
-export const GridContext = createContext<GridContextType<any>>({
+export const GridContext = createContext<GridContextType>({
   gridReady: false,
   prePopupOps: () => {
     console.error("no context provider for prePopupOps");
@@ -125,5 +125,3 @@ export const GridContext = createContext<GridContextType<any>>({
     return true;
   },
 });
-
-export const useGridContext = <RowType extends GridBaseRow>() => useContext<GridContextType<RowType>>(GridContext);

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -23,7 +23,7 @@ export const GridContextProvider = (props: GridContextProps): ReactElement => {
   const idsBeforeUpdate = useRef<number[]>([]);
   const prePopupFocusedCell = useRef<CellPosition>();
   const [externallySelectedItemsAreInSync, setExternallySelectedItemsAreInSync] = useState(false);
-  const externalFilters = useRef<GridFilterExternal<any>[]>([]);
+  const externalFilters = useRef<GridFilterExternal[]>([]);
 
   const setGridApi = useCallback((gridApi: GridApi | undefined) => {
     _setGridApi(gridApi);
@@ -385,12 +385,12 @@ export const GridContextProvider = (props: GridContextProps): ReactElement => {
     [gridApi],
   );
 
-  const addExternalFilter = (filter: GridFilterExternal<any>) => {
+  const addExternalFilter = (filter: GridFilterExternal) => {
     externalFilters.current.push(filter);
     onFilterChanged();
   };
 
-  const removeExternalFilter = (filter: GridFilterExternal<any>) => {
+  const removeExternalFilter = (filter: GridFilterExternal) => {
     remove(externalFilters.current, (v) => v === filter);
     onFilterChanged();
   };

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -1,7 +1,7 @@
-import { ReactElement, ReactNode, useCallback, useContext, useRef, useState } from "react";
+import { ReactElement, ReactNode, useCallback, useContext, useMemo, useRef, useState } from "react";
 import { ColDef, GridApi, RowNode } from "ag-grid-community";
 import { GridContext, GridFilterExternal } from "./GridContext";
-import { defer, delay, difference, isEmpty, last, remove, sortBy } from "lodash-es";
+import { debounce, defer, delay, difference, isEmpty, last, remove, sortBy } from "lodash-es";
 import { isNotEmpty, wait } from "../utils/util";
 import { GridUpdatingContext } from "./GridUpdatingContext";
 import { GridBaseRow } from "../components/Grid";
@@ -377,14 +377,22 @@ export const GridContextProvider = (props: GridContextProps): ReactElement => {
     }
   }, [externallySelectedItemsAreInSync]);
 
+  const onFilterChanged = useMemo(
+    () =>
+      debounce(() => {
+        gridApi && gridApi.onFilterChanged();
+      }, 200),
+    [gridApi],
+  );
+
   const addExternalFilter = (filter: GridFilterExternal<any>) => {
     externalFilters.current.push(filter);
-    gridApi && gridApi.onFilterChanged();
+    onFilterChanged();
   };
 
   const removeExternalFilter = (filter: GridFilterExternal<any>) => {
     remove(externalFilters.current, (v) => v === filter);
-    gridApi && gridApi.onFilterChanged();
+    onFilterChanged();
   };
 
   const isExternalFilterPresent = (): boolean => externalFilters.current.length > 0;

--- a/src/stories/grid/GridPopoverEditBearing.stories.tsx
+++ b/src/stories/grid/GridPopoverEditBearing.stories.tsx
@@ -95,7 +95,6 @@ const GridPopoverEditBearingTemplate: ComponentStory<typeof Grid> = (props: Grid
 
   return (
     <Grid
-      quickFilter={true}
       data-testid={"bearingsTestTable"}
       {...props}
       readOnly={false}

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -207,7 +207,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
       <GridFilters>
         <GridFilterQuick quickFilterPlaceholder={"Custom placeholder..."} />
         <div>
-          Filter: Age less than:
+          Custom filter: Age less than:
           <GridFilterLessThan field={"age"} />
         </div>
       </GridFilters>

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -233,14 +233,13 @@ export const GridFilterLessThan = (props: { field: keyof ITestRow }): JSX.Elemen
 
   useGridFilter(filter);
 
-  const updateValue = useCallback((newValue: string) => {
-    newValue = newValue.trim();
+  const updateValue = (newValue: string) => {
     try {
-      setValue(newValue == "" ? undefined : parseInt(newValue));
+      setValue(newValue.trim() == "" ? undefined : parseInt(newValue));
     } catch {
       // ignore number parse exception
     }
-  }, []);
+  };
 
   return <input type={"text"} defaultValue={value} onChange={(e) => updateValue(e.target.value)} />;
 };

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -16,6 +16,7 @@ import { MenuOption } from "../../components/gridForm/GridFormPopoverMenu";
 import { GridFormSubComponentTextInput } from "../../components/gridForm/GridFormSubComponentTextInput";
 import { GridFormSubComponentTextArea } from "../../components/gridForm/GridFormSubComponentTextArea";
 import { GridIcon } from "../../components/GridIcon";
+import { useGridFilter } from "../../components/GridFilter";
 
 export default {
   title: "Components / Grids",
@@ -201,17 +202,37 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
   ]);
 
   return (
-    <Grid
-      {...props}
-      selectable={true}
-      externalSelectedItems={externalSelectedItems}
-      setExternalSelectedItems={setExternalSelectedItems}
-      columnDefs={columnDefs}
-      rowData={rowData}
-      domLayout={"autoHeight"}
-      autoSelectFirstRow={true}
-    />
+    <>
+      <div>
+        <div>
+          Filter: Age less than:
+          <GridFilterLessThan field={"age"} />
+        </div>
+      </div>
+      <Grid
+        {...props}
+        selectable={true}
+        externalSelectedItems={externalSelectedItems}
+        setExternalSelectedItems={setExternalSelectedItems}
+        columnDefs={columnDefs}
+        rowData={rowData}
+        domLayout={"autoHeight"}
+        autoSelectFirstRow={true}
+      />
+    </>
   );
+};
+
+export const GridFilterLessThan = (props: { field: keyof ITestRow }): JSX.Element => {
+  const [value, setValue] = useState<number>();
+
+  const filter = (data: ITestRow): boolean => {
+    return value == null || data[props.field] < value;
+  };
+
+  useGridFilter(filter);
+
+  return <input type={"text"} defaultValue={value} onChange={(e) => setValue(parseInt(e.target.value))} />;
 };
 
 export const ReadOnlySingleSelection = GridReadOnlyTemplate.bind({});

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -12,11 +12,12 @@ import { wait } from "../../utils/util";
 import { GridPopoverMenu } from "../../components/gridPopoverEdit/GridPopoverMenu";
 import { ColDefT, GridCell } from "../../components/GridCell";
 import { GridPopoverMessage } from "../../components/gridPopoverEdit/GridPopoverMessage";
-import { MenuOption } from "../../components/gridForm/GridFormPopoverMenu";
 import { GridFormSubComponentTextInput } from "../../components/gridForm/GridFormSubComponentTextInput";
 import { GridFormSubComponentTextArea } from "../../components/gridForm/GridFormSubComponentTextArea";
 import { GridIcon } from "../../components/GridIcon";
 import { useGridFilter } from "../../components/GridFilter";
+import { GridFilterQuick } from "../../components/gridFilter/GridFilterQuick";
+import { GridFilters } from "../../components/gridFilter/GridFilters";
 
 export default {
   title: "Components / Grids",
@@ -174,7 +175,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
                     <GridFormSubComponentTextArea placeholder={"Other"} maxLength={5} required defaultValue={""} />
                   ),
                 },
-              ] as MenuOption<ITestRow>[];
+              ];
             },
           },
         },
@@ -203,12 +204,13 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
 
   return (
     <>
-      <div>
+      <GridFilters>
+        <GridFilterQuick quickFilterPlaceholder={"Custom placeholder..."} />
         <div>
           Filter: Age less than:
           <GridFilterLessThan field={"age"} />
         </div>
-      </div>
+      </GridFilters>
       <Grid
         {...props}
         selectable={true}

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -225,7 +225,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
   );
 };
 
-export const GridFilterLessThan = (props: { field: keyof ITestRow }): JSX.Element => {
+const GridFilterLessThan = (props: { field: keyof ITestRow }): JSX.Element => {
   const [value, setValue] = useState<number>();
 
   const filter = useCallback(

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -7,7 +7,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/clien
 import { GridUpdatingContextProvider } from "../../contexts/GridUpdatingContextProvider";
 import { GridContextProvider } from "../../contexts/GridContextProvider";
 import { Grid, GridProps } from "../../components/Grid";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { wait } from "../../utils/util";
 import { GridPopoverMenu } from "../../components/gridPopoverEdit/GridPopoverMenu";
 import { ColDefT, GridCell } from "../../components/GridCell";
@@ -226,13 +226,23 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
 export const GridFilterLessThan = (props: { field: keyof ITestRow }): JSX.Element => {
   const [value, setValue] = useState<number>();
 
-  const filter = (data: ITestRow): boolean => {
-    return value == null || data[props.field] < value;
-  };
+  const filter = useCallback(
+    (data: ITestRow): boolean => value == null || data[props.field] < value,
+    [props.field, value],
+  );
 
   useGridFilter(filter);
 
-  return <input type={"text"} defaultValue={value} onChange={(e) => setValue(parseInt(e.target.value))} />;
+  const updateValue = useCallback((newValue: string) => {
+    newValue = newValue.trim();
+    try {
+      setValue(newValue == "" ? undefined : parseInt(newValue));
+    } catch {
+      // ignore number parse exception
+    }
+  }, []);
+
+  return <input type={"text"} defaultValue={value} onChange={(e) => updateValue(e.target.value)} />;
 };
 
 export const ReadOnlySingleSelection = GridReadOnlyTemplate.bind({});

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -18,6 +18,7 @@ import { GridIcon } from "../../components/GridIcon";
 import { useGridFilter } from "../../components/GridFilter";
 import { GridFilterQuick } from "../../components/gridFilter/GridFilterQuick";
 import { GridFilters } from "../../components/gridFilter/GridFilters";
+import { GridWrapper } from "../../components/GridWrapper";
 
 export default {
   title: "Components / Grids",
@@ -31,7 +32,7 @@ export default {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: 1024, height: 400 }}>
+      <div style={{ width: 1024, height: 400, display: "flex", flexDirection: "column" }}>
         <GridUpdatingContextProvider>
           <GridContextProvider>
             <Story />
@@ -203,7 +204,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
   ]);
 
   return (
-    <>
+    <GridWrapper maxHeight={200}>
       <GridFilters>
         <GridFilterQuick quickFilterPlaceholder={"Custom placeholder..."} />
         <div>
@@ -218,10 +219,9 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
         setExternalSelectedItems={setExternalSelectedItems}
         columnDefs={columnDefs}
         rowData={rowData}
-        domLayout={"autoHeight"}
         autoSelectFirstRow={true}
       />
-    </>
+    </GridWrapper>
   );
 };
 

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -19,11 +19,15 @@
   }
 }
 
-.Grid-quickFilter {
+.Grid-container-filters {
   width: 100%;
   margin-bottom: 16px;
   flex: 0;
+  display: flex;
+  flex-direction: row;
+  grid-column-gap: 1em;
 }
+
 
 .Grid-quickFilterBox {
   width: 100%;

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -9,6 +9,12 @@
   flex-direction: column;
 }
 
+.Grid-wrapper {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 .Grid-sortIsStale {
   span.ag-icon.ag-icon-desc::after {
     content: "*";


### PR DESCRIPTION
QuickFilter moved out of grid and is now it's own component.
Ability to add external filters added.

```
<GridContextProvider>
  <GridWrapper>
    <GridFilters>
      <GridFilterQuick quickFilterPlaceholder={"Custom placeholder..."} />
      <div>
        Custom filter: Age less than:
        <GridFilterLessThan field={"age"} />
      </div>
    </GridFilters>
    <Grid
      {...props}
      selectable={true}
      externalSelectedItems={externalSelectedItems}
      setExternalSelectedItems={setExternalSelectedItems}
      columnDefs={columnDefs}
      rowData={rowData}
      domLayout={"autoHeight"}
      autoSelectFirstRow={true}
    />
  </GridWrapper>
</GridContextProvider>
```