### PR TITLE
feat(column sizing): make onGridSizeChanged, onFirstDataRendered, and suppressColumnVirtualization configurable

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -35,6 +35,9 @@ export interface GridProps {
   autoSelectFirstRow?: boolean;
   onColumnMoved?: GridOptions["onColumnMoved"];
   alwaysShowVerticalScroll?: boolean;
+  onGridSizeChanged: GridOptions["onGridSizeChanged"];
+  onFirstDataRendered: GridOptions["onFirstDataRendered"];
+  suppressColumnVirtualization: GridOptions["suppressColumnVirtualisation"];
 }
 
 /**
@@ -328,8 +331,9 @@ export const Grid = ({ rowSelection = "multiple", "data-testid": dataTestId, ...
           rowSelection={rowSelection}
           suppressBrowserResizeObserver={true}
           colResizeDefault={"shift"}
-          onFirstDataRendered={sizeColumnsToFit}
-          onGridSizeChanged={sizeColumnsToFit}
+          onFirstDataRendered={params.onFirstDataRendered ?? sizeColumnsToFit}
+          onGridSizeChanged={params.onGridSizeChanged ?? sizeColumnsToFit}
+          suppressColumnVirtualisation={params.suppressColumnVirtualization}
           suppressClickEdit={true}
           onCellKeyPress={onCellKeyPress}
           onCellClicked={onCellClicked}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -43,7 +43,12 @@ export interface GridProps {
 /**
  * Wrapper for AgGrid to add commonly used functionality.
  */
-export const Grid = ({ rowSelection = "multiple", "data-testid": dataTestId, ...params }: GridProps): JSX.Element => {
+export const Grid = ({
+  "data-testid": dataTestId,
+  rowSelection = "multiple",
+  suppressColumnVirtualization = true,
+  ...params
+}: GridProps): JSX.Element => {
   const {
     gridReady,
     setApis,
@@ -333,7 +338,7 @@ export const Grid = ({ rowSelection = "multiple", "data-testid": dataTestId, ...
           colResizeDefault={"shift"}
           onFirstDataRendered={params.onFirstDataRendered ?? sizeColumnsToFit}
           onGridSizeChanged={params.onGridSizeChanged ?? sizeColumnsToFit}
-          suppressColumnVirtualisation={params.suppressColumnVirtualization ?? true}
+          suppressColumnVirtualisation={suppressColumnVirtualization}
           suppressClickEdit={true}
           onCellKeyPress={onCellKeyPress}
           onCellClicked={onCellClicked}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -333,7 +333,7 @@ export const Grid = ({ rowSelection = "multiple", "data-testid": dataTestId, ...
           colResizeDefault={"shift"}
           onFirstDataRendered={params.onFirstDataRendered ?? sizeColumnsToFit}
           onGridSizeChanged={params.onGridSizeChanged ?? sizeColumnsToFit}
-          suppressColumnVirtualisation={params.suppressColumnVirtualization}
+          suppressColumnVirtualisation={params.suppressColumnVirtualization ?? true}
           suppressClickEdit={true}
           onCellKeyPress={onCellKeyPress}
           onCellClicked={onCellClicked}


### PR DESCRIPTION
relates to #259 

- Allow users to configure `suppressColumnVirtualization`
- Allow users to override `onFirstDataRendered` and `onGridSizeChanged` callbacks (default to existing behavior of `sizeColumnsToFit`).

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop
