### PR TITLE
fix(GridProps): make optional properties optional

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -37,9 +37,9 @@ export interface GridProps {
   autoSelectFirstRow?: boolean;
   onColumnMoved?: GridOptions["onColumnMoved"];
   alwaysShowVerticalScroll?: boolean;
-  onGridSizeChanged: GridOptions["onGridSizeChanged"];
-  onFirstDataRendered: GridOptions["onFirstDataRendered"];
-  suppressColumnVirtualization: GridOptions["suppressColumnVirtualisation"];
+  onGridSizeChanged?: GridOptions["onGridSizeChanged"];
+  onFirstDataRendered?: GridOptions["onFirstDataRendered"];
+  suppressColumnVirtualization?: GridOptions["suppressColumnVirtualisation"];
 }
 
 /**


### PR DESCRIPTION
onGridSizeChanged, onFirstDataRendered, suppressColumnVirtualization all have defaults and should not be required.

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [x] reasonable code test coverage
- [x] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop
