### PR TITLE
SURVEY-6191 download grid as CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ const GridDemo = () => {
 ## CSV Download
 CSV download relies on column valueFormatters vs ag-grid's default valueGetter implementation.
 If you use a customRenderer for a column be sure to include a valueFormatter.
+To disable this behaviour pass undefined to processCellCallback.
+```<GridFilterDownloadCsvButton processCellCallback={undefined}/>```
 
 To exclude a column from CSV download add ```export: false``` to the GridCell definition. 
-To disable this behaviour pass undefined to processCellCallback. 
-```<GridFilterDownloadCsvButton processCellCallback={undefined}/>```
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Storybook demo deployed at: https://linz.github.io/step-ag-grid/
 Check `src\stories` for more usage examples
 
 ```tsx
-import { useMemo } from "react";
+import {useMemo} from "react";
 
 import "@linzjs/lui/dist/fonts";
 import "@linzjs/lui/dist/scss/base.scss";
@@ -65,6 +65,7 @@ import {
 // Only required for LINZ themes otherwise import the default theme from ag-grid
 import "@linzjs/step-ag-grid/dist/GridTheme.scss";
 import "@linzjs/step-ag-grid/dist/index.css";
+import {GridFilterDownloadCsvButton} from "./GridFilterDownloadCsvButton";
 
 const GridDemo = () => {
   interface ITestRow {
@@ -74,93 +75,98 @@ const GridDemo = () => {
   }
 
   const columnDefs: ColDefT<ITestRow>[] = useMemo(
-    () => [
-      GridCell({
-        field: "id",
-        headerName: "Id",
-        initialWidth: 65,
-        maxWidth: 85,
-      }),
-      GridCell({
-        field: "name",
-        headerName: "Name",
-        initialWidth: 65,
-        maxWidth: 150,
-        cellRendererParams: {
-          warning: ({ value }) => value === "Tester" && "Testers are testing",
-          info: ({ value }) => value === "Developer" && "Developers are awesome",
-        },
-      }),
-      GridPopoverEditDropDown(
-        {
-          field: "position",
-          initialWidth: 65,
-          maxWidth: 150,
-          headerName: "Position",
-        },
-        {
-          multiEdit: false,
-          editorParams: {
-            options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
-          },
-        },
-      ),
-      GridPopoverMessage(
-        {
-          headerName: "Popout message",
-          cellRenderer: () => <>Click me!</>,
-        },
-        {
-          multiEdit: true,
-          editorParams: {
-            message: async ({ selectedRows }) => {
-              return `There are ${selectedRows.length} row(s) selected`;
-            },
-          },
-        },
-      ),
-    ],
-    [],
+          () => [
+            GridCell({
+              field: "id",
+              headerName: "Id",
+              initialWidth: 65,
+              maxWidth: 85,
+            }),
+            GridCell({
+              field: "name",
+              headerName: "Name",
+              initialWidth: 65,
+              maxWidth: 150,
+              cellRendererParams: {
+                warning: ({value}) => value === "Tester" && "Testers are testing",
+                info: ({value}) => value === "Developer" && "Developers are awesome",
+              },
+            }),
+            GridPopoverEditDropDown(
+                    {
+                      field: "position",
+                      initialWidth: 65,
+                      maxWidth: 150,
+                      headerName: "Position",
+                    },
+                    {
+                      multiEdit: false,
+                      editorParams: {
+                        options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
+                      },
+                    },
+            ),
+            GridPopoverMessage(
+                    {
+                      headerName: "Popout message",
+                      cellRenderer: () => <>Click me!</>,
+                    },
+                    {
+                      multiEdit: true,
+                      editorParams: {
+                        message: async ({selectedRows}) => {
+                          return `There are ${selectedRows.length} row(s) selected`;
+                        },
+                      },
+                    },
+            ),
+          ],
+          [],
   );
 
   const rowData: ITestRow[] = useMemo(
-    () => [
-      { id: 1000, name: "Tom", position: "Tester" },
-      { id: 1001, name: "Sue", position: "Developer" },
-    ],
-    [],
+          () => [
+            {id: 1000, name: "Tom", position: "Tester"},
+            {id: 1001, name: "Sue", position: "Developer"},
+          ],
+          [],
   );
 
   return (
-    <GridUpdatingContextProvider>
-      <GridContextProvider>
-        <GridWrapper>
-          <GridFilters>
-            <GridFilterQuick quickFilterPlaceholder={"Search..."} />
-            <GridFilterButtons<ITestRow>
-                    options={[
-                      {
-                        label: "All",
-                      },
-                      {
-                        label: "Developers",
-                        filter: (row) => row.position === "Developer",
-                      },
-                      {
-                        label: "Testers",
-                        filter: (row) => row.position === "Tester",
-                      },
-                    ]}
-            />
-            <GridFilterColumnsToggle/>
-          </GridFilters>
-          <Grid selectable={true} columnDefs={columnDefs} rowData={rowData} />
-        </GridWrapper>
-      </GridContextProvider>
-    </GridUpdatingContextProvider>
+          <GridUpdatingContextProvider>
+            <GridContextProvider>
+              <GridWrapper>
+                <GridFilters>
+                  <GridFilterQuick/>
+                  <GridFilterButtons<ITestRow>
+                          options={[
+                            {
+                              label: "All",
+                            },
+                            {
+                              label: "Developers",
+                              filter: (row) => row.position === "Developer",
+                            },
+                            {
+                              label: "Testers",
+                              filter: (row) => row.position === "Tester",
+                            },
+                          ]}
+                  />
+                  <GridFilterColumnsToggle/>
+                  <GridFilterDownloadCsvButton/>
+                </GridFilters>
+                <Grid selectable={true} columnDefs={columnDefs} rowData={rowData}/>
+              </GridWrapper>
+            </GridContextProvider>
+          </GridUpdatingContextProvider>
   );
 };
 ```
+
+## CSV Download
+CSV download relies on column valueFormatters vs ag-grid's default valueGetter implementation.
+If you use a customRenderer for a column be sure to include a valueFormatter.
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const GridDemo = () => {
               headerName: "Id",
               initialWidth: 65,
               maxWidth: 85,
+              export: false,
             }),
             GridCell({
               field: "name",
@@ -167,6 +168,8 @@ const GridDemo = () => {
 ## CSV Download
 CSV download relies on column valueFormatters vs ag-grid's default valueGetter implementation.
 If you use a customRenderer for a column be sure to include a valueFormatter.
+
+To exclude a column from CSV download add ```export: false``` to the GridCell definition.
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ const GridDemo = () => {
 CSV download relies on column valueFormatters vs ag-grid's default valueGetter implementation.
 If you use a customRenderer for a column be sure to include a valueFormatter.
 
-To exclude a column from CSV download add ```export: false``` to the GridCell definition.
+To exclude a column from CSV download add ```export: false``` to the GridCell definition. 
+To disable this behaviour pass undefined to processCellCallback. 
+```<GridFilterDownloadCsvButton processCellCallback={undefined}/>```
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -89,37 +89,37 @@ const GridDemo = () => {
         initialWidth: 65,
         maxWidth: 150,
         cellRendererParams: {
-          warning: ({value}) => value === "Tester" && "Testers are testing",
-          info: ({value}) => value === "Developer" && "Developers are awesome",
+          warning: ({ value }) => value === "Tester" && "Testers are testing",
+          info: ({ value }) => value === "Developer" && "Developers are awesome",
         },
       }),
       GridPopoverEditDropDown(
-              {
-                field: "position",
-                initialWidth: 65,
-                maxWidth: 150,
-                headerName: "Position",
-              },
-              {
-                multiEdit: false,
-                editorParams: {
-                  options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
-                },
-              },
+        {
+          field: "position",
+          initialWidth: 65,
+          maxWidth: 150,
+          headerName: "Position",
+        },
+        {
+          multiEdit: false,
+          editorParams: {
+            options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
+          },
+        },
       ),
       GridPopoverMessage(
-              {
-                headerName: "Popout message",
-                cellRenderer: () => <>Click me!</>,
-              },
-              {
-                multiEdit: true,
-                editorParams: {
-                  message: async ({selectedRows}) => {
-                    return `There are ${selectedRows.length} row(s) selected`;
-                  },
-                },
-              },
+        {
+          headerName: "Popout message",
+          cellRenderer: () => <>Click me!</>,
+        },
+        {
+          multiEdit: true,
+          editorParams: {
+            message: async ({selectedRows}) => {
+              return `There are ${selectedRows.length} row(s) selected`;
+            },
+          },
+        },
       ),
     ],
     [],
@@ -127,8 +127,8 @@ const GridDemo = () => {
 
   const rowData: ITestRow[] = useMemo(
     () => [
-      {id: 1000, name: "Tom", position: "Tester"},
-      {id: 1001, name: "Sue", position: "Developer"},
+      { id: 1000, name: "Tom", position: "Tester" },
+      { id: 1001, name: "Sue", position: "Developer" },
     ],
     [],
   );
@@ -140,19 +140,19 @@ const GridDemo = () => {
           <GridFilters>
             <GridFilterQuick/>
             <GridFilterButtons<ITestRow>
-                    options={[
-                      {
-                        label: "All",
-                      },
-                      {
-                        label: "Developers",
-                        filter: (row) => row.position === "Developer",
-                      },
-                      {
-                        label: "Testers",
-                        filter: (row) => row.position === "Tester",
-                      },
-                    ]}
+              options={[
+                {
+                  label: "All",
+                },
+                {
+                  label: "Developers",
+                  filter: (row) => row.position === "Developer",
+                },
+                {
+                  label: "Testers",
+                  filter: (row) => row.position === "Tester",
+                },
+              ]}
             />
             <GridFilterColumnsToggle/>
             <GridFilterDownloadCsvButton fileName={"exportFile"}/>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Storybook demo deployed at: https://linz.github.io/step-ag-grid/
 Check `src\stories` for more usage examples
 
 ```tsx
-import {useMemo} from "react";
+import { useMemo } from "react";
 
 import "@linzjs/lui/dist/fonts";
 import "@linzjs/lui/dist/scss/base.scss";
@@ -65,7 +65,7 @@ import {
 // Only required for LINZ themes otherwise import the default theme from ag-grid
 import "@linzjs/step-ag-grid/dist/GridTheme.scss";
 import "@linzjs/step-ag-grid/dist/index.css";
-import {GridFilterDownloadCsvButton} from "./GridFilterDownloadCsvButton";
+import { GridFilterDownloadCsvButton } from "./GridFilterDownloadCsvButton";
 
 const GridDemo = () => {
   interface ITestRow {
@@ -75,92 +75,92 @@ const GridDemo = () => {
   }
 
   const columnDefs: ColDefT<ITestRow>[] = useMemo(
-          () => [
-            GridCell({
-              field: "id",
-              headerName: "Id",
-              initialWidth: 65,
-              maxWidth: 85,
-              export: false,
-            }),
-            GridCell({
-              field: "name",
-              headerName: "Name",
-              initialWidth: 65,
-              maxWidth: 150,
-              cellRendererParams: {
-                warning: ({value}) => value === "Tester" && "Testers are testing",
-                info: ({value}) => value === "Developer" && "Developers are awesome",
+    () => [
+      GridCell({
+        field: "id",
+        headerName: "Id",
+        initialWidth: 65,
+        maxWidth: 85,
+        export: false,
+      }),
+      GridCell({
+        field: "name",
+        headerName: "Name",
+        initialWidth: 65,
+        maxWidth: 150,
+        cellRendererParams: {
+          warning: ({value}) => value === "Tester" && "Testers are testing",
+          info: ({value}) => value === "Developer" && "Developers are awesome",
+        },
+      }),
+      GridPopoverEditDropDown(
+              {
+                field: "position",
+                initialWidth: 65,
+                maxWidth: 150,
+                headerName: "Position",
               },
-            }),
-            GridPopoverEditDropDown(
-                    {
-                      field: "position",
-                      initialWidth: 65,
-                      maxWidth: 150,
-                      headerName: "Position",
-                    },
-                    {
-                      multiEdit: false,
-                      editorParams: {
-                        options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
-                      },
-                    },
-            ),
-            GridPopoverMessage(
-                    {
-                      headerName: "Popout message",
-                      cellRenderer: () => <>Click me!</>,
-                    },
-                    {
-                      multiEdit: true,
-                      editorParams: {
-                        message: async ({selectedRows}) => {
-                          return `There are ${selectedRows.length} row(s) selected`;
-                        },
-                      },
-                    },
-            ),
-          ],
-          [],
+              {
+                multiEdit: false,
+                editorParams: {
+                  options: ["Architect", "Developer", "Product Owner", "Scrum Master", "Tester", MenuSeparator, "(other)"],
+                },
+              },
+      ),
+      GridPopoverMessage(
+              {
+                headerName: "Popout message",
+                cellRenderer: () => <>Click me!</>,
+              },
+              {
+                multiEdit: true,
+                editorParams: {
+                  message: async ({selectedRows}) => {
+                    return `There are ${selectedRows.length} row(s) selected`;
+                  },
+                },
+              },
+      ),
+    ],
+    [],
   );
 
   const rowData: ITestRow[] = useMemo(
-          () => [
-            {id: 1000, name: "Tom", position: "Tester"},
-            {id: 1001, name: "Sue", position: "Developer"},
-          ],
-          [],
+    () => [
+      {id: 1000, name: "Tom", position: "Tester"},
+      {id: 1001, name: "Sue", position: "Developer"},
+    ],
+    [],
   );
 
   return (
-          <GridUpdatingContextProvider>
-            <GridContextProvider>
-              <GridWrapper>
-                <GridFilters>
-                  <GridFilterQuick/>
-                  <GridFilterButtons<ITestRow>
-                          options={[
-                            {
-                              label: "All",
-                            },
-                            {
-                              label: "Developers",
-                              filter: (row) => row.position === "Developer",
-                            },
-                            {
-                              label: "Testers",
-                              filter: (row) => row.position === "Tester",
-                            },
-                          ]}
-                  />
-                  <GridFilterColumnsToggle/>
-                  <GridFilterDownloadCsvButton fileName={"exportFile"}/>
-                </GridFilters>
-                <Grid selectable={true} columnDefs={columnDefs} rowData={rowData}/>
-              </GridWrapper>
-            </GridContextProvider>
-          </GridUpdatingContextProvider>
+    <GridUpdatingContextProvider>
+      <GridContextProvider>
+        <GridWrapper>
+          <GridFilters>
+            <GridFilterQuick/>
+            <GridFilterButtons<ITestRow>
+                    options={[
+                      {
+                        label: "All",
+                      },
+                      {
+                        label: "Developers",
+                        filter: (row) => row.position === "Developer",
+                      },
+                      {
+                        label: "Testers",
+                        filter: (row) => row.position === "Tester",
+                      },
+                    ]}
+            />
+            <GridFilterColumnsToggle/>
+            <GridFilterDownloadCsvButton fileName={"exportFile"}/>
+          </GridFilters>
+          <Grid selectable={true} columnDefs={columnDefs} rowData={rowData}/>
+        </GridWrapper>
+      </GridContextProvider>
+    </GridUpdatingContextProvider>
   );
 };
 ```

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const GridDemo = () => {
                           ]}
                   />
                   <GridFilterColumnsToggle/>
-                  <GridFilterDownloadCsvButton/>
+                  <GridFilterDownloadCsvButton fileName={"exportFile"}/>
                 </GridFilters>
                 <Grid selectable={true} columnDefs={columnDefs} rowData={rowData}/>
               </GridWrapper>

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -187,6 +187,9 @@ export const Grid = ({
             colId: "selection",
             editable: false,
             minWidth: 42,
+            headerComponentParams: {
+              exportable: false,
+            },
             maxWidth: 42,
             suppressSizeToFit: true,
             checkboxSelection: true,
@@ -344,6 +347,7 @@ export const Grid = ({
           alwaysShowVerticalScroll={params.alwaysShowVerticalScroll}
           isExternalFilterPresent={isExternalFilterPresent}
           doesExternalFilterPass={doesExternalFilterPass}
+          maintainColumnOrder={true}
         />
       </div>
     </div>

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -114,6 +114,9 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
   // This is so that e.g. bearings can be searched for by DMS or raw number.
   const valueFormatter = props.valueFormatter;
   const filterValueGetter = generateFilterGetter(props.field, props.filterValueGetter, valueFormatter);
+  const exportable = props.exportable;
+  // Can't leave this here ag-grid will complain
+  delete props.exportable;
 
   return {
     colId: props.field,
@@ -143,6 +146,10 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
     cellRendererParams: {
       originalCellRenderer: props.cellRenderer,
       ...props.cellRendererParams,
+    },
+    headerComponentParams: {
+      exportable,
+      ...props.headerComponentParams,
     },
   };
 };

--- a/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
+++ b/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
@@ -1,16 +1,43 @@
 import { CsvExportParams } from "ag-grid-community/dist/lib/interfaces/exportParams";
-import { useContext } from "react";
+import { delay } from "lodash-es";
+import { useContext, useState } from "react";
+
+import { LuiMiniSpinner } from "@linzjs/lui";
 
 import { GridContext } from "../../contexts/GridContext";
+import { useStateDeferred } from "../../lui/stateDeferredHook";
 import { GridFilterHeaderIconButton } from "./GridFilterHeaderIconButton";
 
 export const GridFilterDownloadCsvButton = (csvExportParams: CsvExportParams) => {
   const { downloadCsv } = useContext(GridContext);
-  return (
+
+  const [downloading, setDownloading, setDownloadingDeferred] = useStateDeferred(false);
+
+  const handleDownloadClick = () => {
+    setDownloading(true);
+    // Defer the download such that the component disabled state can update
+    delay(() => {
+      downloadCsv(csvExportParams);
+      // Defer re-enablement as the browser takes time to process the download
+      setDownloadingDeferred(false, 4000);
+    }, 100);
+  };
+
+  return downloading ? (
+    <LuiMiniSpinner
+      size={22}
+      divProps={{
+        role: "status",
+        ["aria-label"]: "Downloading...",
+        style: { width: 42, display: "flex", justifyContent: "center" },
+      }}
+    />
+  ) : (
     <GridFilterHeaderIconButton
       icon={"ic_save_download"}
-      title={"Download CSV"}
-      onClick={() => downloadCsv(csvExportParams)}
+      title={downloading ? "Downloading..." : "Download CSV"}
+      onClick={handleDownloadClick}
+      disabled={downloading}
     />
   );
 };

--- a/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
+++ b/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
@@ -35,7 +35,7 @@ export const GridFilterDownloadCsvButton = (csvExportParams: CsvExportParams) =>
   ) : (
     <GridFilterHeaderIconButton
       icon={"ic_save_download"}
-      title={downloading ? "Downloading..." : "Download CSV"}
+      title={"Download CSV"}
       onClick={handleDownloadClick}
       disabled={downloading}
     />

--- a/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
+++ b/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
@@ -1,6 +1,6 @@
 import { CsvExportParams } from "ag-grid-community/dist/lib/interfaces/exportParams";
 import { delay } from "lodash-es";
-import { useContext, useState } from "react";
+import { useContext } from "react";
 
 import { LuiMiniSpinner } from "@linzjs/lui";
 

--- a/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
+++ b/src/components/gridFilter/GridFilterDownloadCsvButton.tsx
@@ -1,0 +1,16 @@
+import { CsvExportParams } from "ag-grid-community/dist/lib/interfaces/exportParams";
+import { useContext } from "react";
+
+import { GridContext } from "../../contexts/GridContext";
+import { GridFilterHeaderIconButton } from "./GridFilterHeaderIconButton";
+
+export const GridFilterDownloadCsvButton = (csvExportParams: CsvExportParams) => {
+  const { downloadCsv } = useContext(GridContext);
+  return (
+    <GridFilterHeaderIconButton
+      icon={"ic_save_download"}
+      title={"Download CSV"}
+      onClick={() => downloadCsv(csvExportParams)}
+    />
+  );
+};

--- a/src/components/gridFilter/GridFilterHeaderIconButton.tsx
+++ b/src/components/gridFilter/GridFilterHeaderIconButton.tsx
@@ -19,7 +19,7 @@ export const GridFilterHeaderIconButton = forwardRef<HTMLButtonElement, GridFilt
         {...buttonProps}
         type={"button"}
         level={"tertiary"}
-        className={"GridFilterHeaderIconButton lui-button-icon-only"}
+        className={"lui-button-icon-only"}
         ref={ref}
         aria-label={title}
         title={title}

--- a/src/components/gridFilter/GridFilterQuick.tsx
+++ b/src/components/gridFilter/GridFilterQuick.tsx
@@ -16,15 +16,17 @@ export const GridFilterQuick = ({ quickFilterPlaceholder, defaultValue }: GridFi
   }, [quickFilterValue, setQuickFilter]);
 
   return (
-    <input
-      aria-label="Search"
-      className="Grid-quickFilterBox"
-      type="text"
-      placeholder={quickFilterPlaceholder ?? "Search..."}
-      value={quickFilterValue}
-      onChange={(event) => {
-        setQuickFilterValue(event.target.value);
-      }}
-    />
+    <div className="GridFilterQuick-container">
+      <input
+        aria-label="Search"
+        className="GridFilterQuick-input"
+        type="text"
+        placeholder={quickFilterPlaceholder ?? "Search..."}
+        value={quickFilterValue}
+        onChange={(event) => {
+          setQuickFilterValue(event.target.value);
+        }}
+      />
+    </div>
   );
 };

--- a/src/components/gridFilter/index.ts
+++ b/src/components/gridFilter/index.ts
@@ -3,4 +3,5 @@ export * from "./GridFilterColumnsToggle";
 export * from "./GridFilterButtons";
 export * from "./GridFilterQuick";
 export * from "./GridFilters";
+export * from "./GridFilterDownloadCsvButton";
 export * from "./useGridFilter";

--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -17,6 +17,7 @@ export const GridPopoverMenu = <RowType extends GridBaseRow>(
       maxWidth: 48,
       width: 40,
       editable: colDef.editable != null ? colDef.editable : true,
+      exportable: false,
       cellStyle: { justifyContent: "center" },
       cellRenderer: GridRenderPopoutMenuCell,
       ...colDef,

--- a/src/components/gridRender/GridRenderGenericCell.tsx
+++ b/src/components/gridRender/GridRenderGenericCell.tsx
@@ -35,6 +35,7 @@ export interface GenericCellColDef<RowType extends GridBaseRow> extends ColDefT<
   valueFormatter?: string | ((params: RowValueFormatterParams<RowType>) => string);
   filterValueGetter?: string | ((params: RowValueGetterParams<RowType>) => string);
   editable?: boolean | ((params: RowEditableCallbackParams<RowType>) => boolean);
+  exportable?: boolean;
 }
 
 export interface GenericCellRendererParams<RowType extends GridBaseRow> {

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -1,4 +1,5 @@
 import { ColumnApi, GridApi, RowNode } from "ag-grid-community";
+import { CsvExportParams } from "ag-grid-community/dist/lib/interfaces/exportParams";
 import { createContext, useContext } from "react";
 
 import { ColDefT, GridBaseRow } from "../components";
@@ -43,6 +44,7 @@ export interface GridContextType<RowType extends GridBaseRow> {
   getColumns: () => ColDefT<RowType>[];
   invisibleColumnIds: string[];
   setInvisibleColumnIds: (colIds: string[]) => void;
+  downloadCsv: (csvExportParams?: CsvExportParams) => void;
 }
 
 export const GridContext = createContext<GridContextType<any>>({
@@ -145,6 +147,9 @@ export const GridContext = createContext<GridContextType<any>>({
   doesExternalFilterPass: () => {
     console.error("no context provider for doesExternalFilterPass");
     return true;
+  },
+  downloadCsv: () => {
+    console.error("no context provider for downloadCsv");
   },
 });
 

--- a/src/contexts/GridContextProvider.test.tsx
+++ b/src/contexts/GridContextProvider.test.tsx
@@ -1,0 +1,37 @@
+import { ValueFormatterParams } from "ag-grid-community/dist/lib/entities/colDef";
+
+import { downloadCsvUseValueFormattersProcessCellCallback as Dpcc } from "./GridContextProvider";
+
+describe("downloadCsvUseValueFormattersProcessCellCallback", () => {
+  test("each type of value for conversion to string", async () => {
+    expect(Dpcc({ value: undefined } as any)).toBe("undefined");
+    expect(Dpcc({ value: null } as any)).toBe("null");
+    expect(Dpcc({ value: false } as any)).toBe("false");
+    expect(Dpcc({ value: "x" } as any)).toBe("x");
+    expect(Dpcc({ value: 123 } as any)).toBe("123");
+    expect(Dpcc({ value: {} } as any)).toBe("[object Object]");
+    expect(Dpcc({ value: {}, column: { getColDef: () => undefined } } as any)).toBe("[object Object]");
+    expect(Dpcc({ value: {}, column: { getColDef: () => ({ valueFormatter: undefined }) } } as any)).toBe(
+      "[object Object]",
+    );
+    expect(
+      Dpcc({
+        value: {},
+        column: { getColDef: () => ({ valueFormatter: "registeredValueFormatter" }) },
+      } as any),
+    ).toBe("[object Object]");
+
+    expect(
+      Dpcc({
+        value: { a: 2 },
+        column: {
+          getColDef: () => ({
+            valueFormatter: (params: ValueFormatterParams) => {
+              return "xxx" + params.value.a;
+            },
+          }),
+        },
+      } as any),
+    ).toBe("xxx2");
+  });
+});

--- a/src/contexts/GridContextProvider.test.tsx
+++ b/src/contexts/GridContextProvider.test.tsx
@@ -4,22 +4,24 @@ import { downloadCsvUseValueFormattersProcessCellCallback as Dpcc } from "./Grid
 
 describe("downloadCsvUseValueFormattersProcessCellCallback", () => {
   test("each type of value for conversion to string", async () => {
-    expect(Dpcc({ value: undefined } as any)).toBe("undefined");
-    expect(Dpcc({ value: null } as any)).toBe("null");
+    expect(Dpcc({ value: undefined } as any)).toBe("");
+    expect(Dpcc({ value: "-" } as any)).toBe("");
+    expect(Dpcc({ value: "–" } as any)).toBe("");
+    expect(Dpcc({ value: null } as any)).toBe("");
     expect(Dpcc({ value: false } as any)).toBe("false");
     expect(Dpcc({ value: "x" } as any)).toBe("x");
     expect(Dpcc({ value: 123 } as any)).toBe("123");
-    expect(Dpcc({ value: {} } as any)).toBe("[object Object]");
-    expect(Dpcc({ value: {}, column: { getColDef: () => undefined } } as any)).toBe("[object Object]");
-    expect(Dpcc({ value: {}, column: { getColDef: () => ({ valueFormatter: undefined }) } } as any)).toBe(
-      "[object Object]",
+    expect(Dpcc({ value: { a: 2 } } as any)).toBe('{"a":2}');
+    expect(Dpcc({ value: { a: 2 }, column: { getColDef: () => undefined } } as any)).toBe('{"a":2}');
+    expect(Dpcc({ value: { a: 2 }, column: { getColDef: () => ({ valueFormatter: undefined }) } } as any)).toBe(
+      '{"a":2}',
     );
     expect(
       Dpcc({
-        value: {},
+        value: { a: 2 },
         column: { getColDef: () => ({ valueFormatter: "registeredValueFormatter" }) },
       } as any),
-    ).toBe("[object Object]");
+    ).toBe('{"a":2}');
 
     expect(
       Dpcc({

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -565,7 +565,7 @@ export const downloadCsvUseValueFormattersProcessCellCallback = (params: Process
   // If no valueFormatter then value _must_ be a string
   if (valueFormatter == null) {
     if (params.value != null && typeof params.value !== "string") {
-      console.error("downloadCsv: valueFormatter missing and getValue is not a string, colDef:", colDef);
+      console.error(`downloadCsv: valueFormatter missing and getValue is not a string, colId: ${colDef.colId}`);
     }
     return encodeToString(params.value);
   }
@@ -573,15 +573,14 @@ export const downloadCsvUseValueFormattersProcessCellCallback = (params: Process
   // We don't have access to registered functions, so we can't call them
   if (typeof valueFormatter !== "function") {
     console.error(
-      "downloadCsv: String type (registered) value formatters are unsupported in downloadCsv, colDef:",
-      colDef,
+      `downloadCsv: String type (registered) value formatters are unsupported in downloadCsv, colId: ${colDef.colId}`,
     );
     return encodeToString(params.value);
   }
 
   const result = valueFormatter({ ...params, data: params.node?.data, colDef } as ValueFormatterParams);
   if (params.value != null && typeof result !== "string") {
-    console.error("downloadCsv: valueFormatter is returning non string values, colDef:", colDef);
+    console.error(`downloadCsv: valueFormatter is returning non string values, colDef:", colId: ${colDef.colId}`);
   }
   // We add an extra encodeToString here just in case valueFormatter is returning non string values
   return encodeToString(result);

--- a/src/stories/grid/GridPopoverEditBearing.stories.tsx
+++ b/src/stories/grid/GridPopoverEditBearing.stories.tsx
@@ -9,10 +9,15 @@ import {
   Grid,
   GridCell,
   GridContextProvider,
+  GridFilterColumnsToggle,
+  GridFilterDownloadCsvButton,
+  GridFilterQuick,
+  GridFilters,
   GridPopoverEditBearing,
   GridPopoverEditBearingCorrection,
   GridProps,
   GridUpdatingContextProvider,
+  GridWrapper,
   wait,
 } from "../..";
 import "../../styles/GridTheme.scss";
@@ -97,16 +102,23 @@ const GridPopoverEditBearingTemplate: ComponentStory<typeof Grid> = (props: Grid
   ] as ITestRow[]);
 
   return (
-    <Grid
-      data-testid={"bearingsTestTable"}
-      {...props}
-      readOnly={false}
-      externalSelectedItems={externalSelectedItems}
-      setExternalSelectedItems={setExternalSelectedItems}
-      columnDefs={columnDefs}
-      rowData={rowData}
-      domLayout={"autoHeight"}
-    />
+    <GridWrapper maxHeight={300}>
+      <GridFilters>
+        <GridFilterQuick />
+        <GridFilterColumnsToggle />
+        <GridFilterDownloadCsvButton fileName={"customFilename"} />
+      </GridFilters>
+      <Grid
+        data-testid={"bearingsTestTable"}
+        {...props}
+        readOnly={false}
+        externalSelectedItems={externalSelectedItems}
+        setExternalSelectedItems={setExternalSelectedItems}
+        columnDefs={columnDefs}
+        rowData={rowData}
+        domLayout={"autoHeight"}
+      />
+    </GridWrapper>
   );
 };
 

--- a/src/stories/grid/GridPopoverEditDropDown.stories.tsx
+++ b/src/stories/grid/GridPopoverEditDropDown.stories.tsx
@@ -9,12 +9,17 @@ import {
   Grid,
   GridCell,
   GridContextProvider,
+  GridFilterColumnsToggle,
+  GridFilterDownloadCsvButton,
+  GridFilterQuick,
+  GridFilters,
   GridFormSubComponentTextArea,
   GridFormSubComponentTextInput,
   GridPopoverEditDropDown,
   GridPopoverMenu,
   GridProps,
   GridUpdatingContextProvider,
+  GridWrapper,
   MenuHeaderItem,
   MenuSeparator,
   MenuSeparatorString,
@@ -299,14 +304,21 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
   ] as ITestRow[]);
 
   return (
-    <Grid
-      {...props}
-      externalSelectedItems={externalSelectedItems}
-      setExternalSelectedItems={setExternalSelectedItems}
-      columnDefs={columnDefs}
-      rowData={rowData}
-      domLayout={"autoHeight"}
-    />
+    <GridWrapper maxHeight={300}>
+      <GridFilters>
+        <GridFilterQuick />
+        <GridFilterColumnsToggle />
+        <GridFilterDownloadCsvButton fileName={"customFilename"} />
+      </GridFilters>
+      <Grid
+        {...props}
+        externalSelectedItems={externalSelectedItems}
+        setExternalSelectedItems={setExternalSelectedItems}
+        columnDefs={columnDefs}
+        rowData={rowData}
+        domLayout={"autoHeight"}
+      />
+    </GridWrapper>
   );
 };
 

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -266,7 +266,7 @@ const GridFilterLessThan = (props: { field: keyof ITestRow; text: string }): JSX
   };
 
   return (
-    <div className={"flex-row-center"}>
+    <div className={"GridFilter-container flex-row-center"}>
       <div style={{ whiteSpace: "nowrap" }}>{props.text}</div>
       &#160;
       <input type={"text"} defaultValue={value} onChange={(e) => updateValue(e.target.value)} style={{ width: 64 }} />

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -24,6 +24,7 @@ import {
   wait,
 } from "../..";
 import { GridFilterColumnsToggle } from "../../components";
+import { GridFilterDownloadCsvButton } from "../../components/gridFilter/GridFilterDownloadCsvButton";
 import "../../styles/GridTheme.scss";
 import "../../styles/index.scss";
 
@@ -96,6 +97,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
           headerName: "Popout message",
           maxWidth: 150,
           cellRenderer: () => <>Single Click me!</>,
+          exportable: false,
         },
         {
           multiEdit: true,
@@ -214,7 +216,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
   return (
     <GridWrapper maxHeight={300}>
       <GridFilters>
-        <GridFilterQuick quickFilterPlaceholder={"Custom placeholder..."} />
+        <GridFilterQuick />
         <GridFilterLessThan text="Age <" field={"age"} />
         <GridFilterButtons<ITestRow>
           luiButtonProps={{ style: { whiteSpace: "nowrap" } }}
@@ -229,6 +231,7 @@ const GridReadOnlyTemplate: ComponentStory<typeof Grid> = (props: GridProps) => 
           ]}
         />
         <GridFilterColumnsToggle />
+        <GridFilterDownloadCsvButton />
       </GridFilters>
       <Grid
         data-testid={"readonly"}

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -41,7 +41,15 @@
   margin-left: 0 !important;
 }
 
-.Grid-quickFilterBox {
+.GridFilterQuick-container {
+  flex: 1;
+
+  &:not(:last-child) {
+    margin-right: 8px;
+  }
+}
+
+.GridFilterQuick-input {
   width: 100%;
   height: 40px;
   border: 0.06rem solid colors.$silver;
@@ -49,10 +57,6 @@
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   font-family: "Open Sans", system-ui, sans-serif;
-
-  &:not(:last-child) {
-    margin-right: 8px;
-  }
 }
 
 .Grid-popoverContainer {

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -27,15 +27,19 @@
 
 .Grid-container-filters {
   width: 100%;
-  margin-bottom: 16px;
   flex: 0;
   display: flex;
   align-items: center;
   flex-direction: row;
-  grid-column-gap: 1em;
-  padding: 0.25rem 0;
+  padding: 16px;
+  background-color: colors.$hint;
+  border-bottom: 1px solid colors.$silver;
+  border-top: 2px solid colors.$lily;
 }
 
+.Grid-container-filters button {
+  margin-left: 0 !important;
+}
 
 .Grid-quickFilterBox {
   width: 100%;
@@ -45,6 +49,10 @@
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   font-family: "Open Sans", system-ui, sans-serif;
+
+  &:not(:last-child) {
+    margin-right: 8px;
+  }
 }
 
 .Grid-popoverContainer {

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -41,12 +41,15 @@
   margin-left: 0 !important;
 }
 
-.GridFilterQuick-container {
-  flex: 1;
-
+.GridFilter-container {
   &:not(:last-child) {
     margin-right: 8px;
   }
+}
+
+.GridFilterQuick-container {
+  @extend .GridFilter-container;
+  flex: 1;
 }
 
 .GridFilterQuick-input {

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -41,14 +41,18 @@
   margin-left: 0 !important;
 }
 
-.GridFilter-container {
+%GridFilter-container {
   &:not(:last-child) {
     margin-right: 8px;
   }
 }
 
+.GridFilter-container {
+  @extend %GridFilter-container;
+}
+
 .GridFilterQuick-container {
-  @extend .GridFilter-container;
+  @extend %GridFilter-container;
   flex: 1;
 }
 


### PR DESCRIPTION
SURVEY-6191 download grid as CSV

Implement ag-grids download functionality into step ag-grid.
* Added button <GridFilterDownloadCsvButton fileName={"exportFile"}/>
* Added custom processor for cells to return valueFormatter not valueGetter
* Fixed up styles to conform to UIX design
* Fixed waitForExternallySelectedItemsToBeInSync not working.
* Turn on maintainColumnOrder={true} by default on grid to stop columns resetting on update.
![image](https://github.com/linz/step-ag-grid/assets/89495499/303ccdce-d2ee-4c83-99f9-fa3fa204cf4f)

![image](https://github.com/linz/step-ag-grid/assets/89495499/d711e34b-68af-4803-ad95-b30f4cd5215b)
