### PR TITLE
Tab whilst editing edits next available field

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ const GridDemo = () => {
 };
 ```
 
+## Bulk editing
+If you are editing a cell and tab out of the cell, the grid will edit the next editable cell.
+
+At this point you can send the change to the back-end immediately and then wait for an update response
+_OR_
+you could cache the required change, update then cell locally, and then wait for the callback
+```<Grid onCellEditingComplete={fn}/>``` which will get invoked when the grid cannot find any
+more editable cells on the grid row, which will speed up editing.
+
 ## Grid sizing
 Grid uses ```<Grid sizeColumns="auto"/>``` which sizes by cell content by default.
 To ignore cell content use "fit", to disable use "none".

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -230,9 +230,7 @@ export const Grid = ({
   /**
    * Synchronise externally selected items to grid on externalSelectedItems change
    */
-  useEffect(() => {
-    synchroniseExternallySelectedItemsToGrid();
-  }, [synchroniseExternallySelectedItemsToGrid]);
+  useEffect(() => synchroniseExternallySelectedItemsToGrid(), [synchroniseExternallySelectedItemsToGrid]);
 
   const columnDefs = useMemo((): ColDef[] => {
     const adjustColDefs = params.columnDefs.map((colDef) => {
@@ -297,15 +295,14 @@ export const Grid = ({
    * This will resize columns when we have at least one row.
    */
   const previousRowDataLength = useRef(0);
-  useEffect(() => {
-    if (!gridReady) return;
 
+  const onRowDataChanged = useCallback(() => {
     const length = params.rowData?.length ?? 0;
     if (previousRowDataLength.current !== length) {
       setInitialContentSize();
       previousRowDataLength.current = length;
     }
-  }, [gridReady, params.rowData?.length, setInitialContentSize]);
+  }, [params.rowData?.length, setInitialContentSize]);
 
   const onModelUpdated = useCallback((event: ModelUpdatedEvent) => {
     event.api.getDisplayedRowCount() === 0 ? event.api.showNoRowsOverlay() : event.api.hideOverlay();
@@ -456,6 +453,7 @@ export const Grid = ({
           onGridSizeChanged={onGridSizeChanged}
           suppressColumnVirtualisation={suppressColumnVirtualization}
           suppressClickEdit={true}
+          onRowDataChanged={onRowDataChanged}
           onCellKeyPress={onCellKeyPress}
           onCellClicked={onCellClicked}
           onCellDoubleClicked={onCellDoubleClick}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -56,6 +56,11 @@ export interface GridProps {
    * If you want to stretch to container width if width is greater than the container add a flex column.
    */
   sizeColumns?: "fit" | "auto" | "auto-skip-headers" | "none";
+  /**
+   * When pressing tab whilst editing the grid will select and edit the next cell if available.
+   * Once the last cell to edit closes this callback is called.
+   */
+  onCellEditingComplete?: () => void;
 }
 
 /**
@@ -84,6 +89,7 @@ export const Grid = ({
     setExternallySelectedItemsAreInSync,
     isExternalFilterPresent,
     doesExternalFilterPass,
+    setOnCellEditingComplete,
   } = useContext(GridContext);
   const { checkUpdating } = useContext(GridUpdatingContext);
 
@@ -377,6 +383,8 @@ export const Grid = ({
       })),
     [columnDefs, sizeColumns],
   );
+
+  setOnCellEditingComplete(params.onCellEditingComplete);
 
   return (
     <div

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -105,6 +105,7 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
   props: GenericCellColDef<RowType>,
   custom?: {
     multiEdit?: boolean;
+    preventAutoEdit?: boolean;
     editor?: (editorProps: Props) => JSX.Element;
     editorParams?: Props;
   },
@@ -132,7 +133,11 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
     }),
     suppressKeyboardEvent: suppressCellKeyboardEvents,
     ...(custom?.editorParams && {
-      cellEditorParams: { ...custom.editorParams, multiEdit: custom.multiEdit },
+      cellEditorParams: {
+        ...custom.editorParams,
+        multiEdit: custom.multiEdit,
+        preventAutoEdit: custom.preventAutoEdit ?? false,
+      },
     }),
     // If there's a valueFormatter and no filterValueGetter then create a filterValueGetter
     filterValueGetter,

--- a/src/components/GridCell.tsx
+++ b/src/components/GridCell.tsx
@@ -124,7 +124,6 @@ export const GridCell = <RowType extends GridBaseRow, Props extends CellEditorCo
     headerTooltip: props.headerName,
     sortable: !!(props?.field || props?.valueGetter),
     resizable: true,
-    minWidth: props.flex ? 150 : 48,
     editable: props.editable ?? false,
     ...(custom?.editor && {
       cellClassRules: GridCellMultiSelectClassRules,

--- a/src/components/GridPopoverHook.tsx
+++ b/src/components/GridPopoverHook.tsx
@@ -21,7 +21,7 @@ export interface GridPopoverHookProps<RowType> {
 }
 
 export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopoverHookProps<RowType>) => {
-  const { stopEditing } = useContext(GridContext);
+  const { stopEditing, cancelEdit } = useContext(GridContext);
   const { anchorRef, saving, updateValue } = useGridPopoverContext<RowType>();
   const saveButtonRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setOpen] = useState(false);
@@ -33,7 +33,7 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
   const triggerSave = useCallback(
     async (reason?: string) => {
       if (reason == CloseReason.CANCEL) {
-        stopEditing();
+        cancelEdit();
         return;
       }
       if (props.invalid && props.invalid()) {
@@ -41,7 +41,7 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
       }
 
       if (!props.save) {
-        stopEditing();
+        cancelEdit();
       } else if (props.save) {
         // forms that don't provide an invalid fn must wait until they have saved to close
         if (props.invalid) stopEditing();
@@ -55,7 +55,7 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
         }
       }
     },
-    [props, stopEditing, updateValue],
+    [cancelEdit, props, stopEditing, updateValue],
   );
 
   const popoverWrapper = useCallback(

--- a/src/components/gridForm/GridFormDropDown.tsx
+++ b/src/components/gridForm/GridFormDropDown.tsx
@@ -115,14 +115,7 @@ export const GridFormDropDown = <RowType extends GridBaseRow>(props: GridFormDro
             : item,
         );
 
-        if (props.filtered) {
-          // This is needed otherwise when filter input is rendered and sets autofocus
-          // the mouse up of the double click edit triggers the cell to cancel editing
-          setOptions(optionsList);
-          //delay(() => setOptions(optionsList), 100);
-        } else {
-          setOptions(optionsList);
-        }
+        setOptions(optionsList);
       }
     })();
   }, [filter, options, props, selectedRows]);

--- a/src/components/gridPopoverEdit/GridPopoverMenu.tsx
+++ b/src/components/gridPopoverEdit/GridPopoverMenu.tsx
@@ -28,6 +28,7 @@ export const GridPopoverMenu = <RowType extends GridBaseRow>(
     },
     {
       editor: GridFormPopoverMenu,
+      preventAutoEdit: true,
       ...custom,
     },
   );

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -47,6 +47,7 @@ export interface GridContextType<RowType extends GridBaseRow> {
   invisibleColumnIds: string[];
   setInvisibleColumnIds: (colIds: string[]) => void;
   downloadCsv: (csvExportParams?: CsvExportParams) => void;
+  setOnCellEditingComplete: (callback: (() => void) | undefined) => void;
 }
 
 export const GridContext = createContext<GridContextType<any>>({
@@ -161,6 +162,9 @@ export const GridContext = createContext<GridContextType<any>>({
   },
   downloadCsv: () => {
     console.error("no context provider for downloadCsv");
+  },
+  setOnCellEditingComplete: () => {
+    console.error("no context provider for setOnCellEditingComplete");
   },
 });
 

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -28,6 +28,7 @@ export interface GridContextType<RowType extends GridBaseRow> {
   getFirstRowId: () => number;
   autoSizeAllColumns: (props?: { skipHeader?: boolean }) => { width: number } | null;
   sizeColumnsToFit: () => void;
+  cancelEdit: () => void;
   stopEditing: () => void;
   updatingCells: (
     props: { selectedRows: GridBaseRow[]; field?: string },
@@ -129,6 +130,9 @@ export const GridContext = createContext<GridContextType<any>>({
   editingCells: () => {
     console.error("no context provider for editingCells");
     return false;
+  },
+  cancelEdit: () => {
+    console.error("no context provider for cancelEdit");
   },
   stopEditing: () => {
     console.error("no context provider for stopEditing");

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -26,7 +26,11 @@ export interface GridContextType<RowType extends GridBaseRow> {
   ensureRowVisible: (id: number | string) => boolean;
   ensureSelectedRowIsVisible: () => void;
   getFirstRowId: () => number;
-  autoSizeAllColumns: (props?: { skipHeader?: boolean }) => { width: number } | null;
+  autoSizeAllColumns: (props?: {
+    skipHeader?: boolean;
+    colIds?: string[];
+    userSizedColIds?: Set<string>;
+  }) => { width: number } | null;
   sizeColumnsToFit: () => void;
   cancelEdit: () => void;
   stopEditing: () => void;

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -6,6 +6,14 @@ import { ColDefT, GridBaseRow } from "../components";
 
 export type GridFilterExternal<RowType extends GridBaseRow> = (data: RowType, rowNode: RowNode) => boolean;
 
+export interface AutoSizeColumnsProps {
+  skipHeader?: boolean;
+  colIds?: Set<string> | string[];
+  userSizedColIds?: Set<string>;
+}
+
+export type AutoSizeColumnsResult = { width: number } | null;
+
 export interface GridContextType<RowType extends GridBaseRow> {
   gridReady: boolean;
   setApis: (gridApi: GridApi | undefined, columnApi: ColumnApi | undefined, dataTestId?: string) => void;
@@ -26,11 +34,7 @@ export interface GridContextType<RowType extends GridBaseRow> {
   ensureRowVisible: (id: number | string) => boolean;
   ensureSelectedRowIsVisible: () => void;
   getFirstRowId: () => number;
-  autoSizeAllColumns: (props?: {
-    skipHeader?: boolean;
-    colIds?: string[];
-    userSizedColIds?: Set<string>;
-  }) => { width: number } | null;
+  autoSizeColumns: (props?: AutoSizeColumnsProps) => AutoSizeColumnsResult;
   sizeColumnsToFit: () => void;
   cancelEdit: () => void;
   stopEditing: () => void;
@@ -123,8 +127,8 @@ export const GridContext = createContext<GridContextType<any>>({
     console.error("no context provider for getFirstRowId");
     return -1;
   },
-  autoSizeAllColumns: () => {
-    console.error("no context provider for autoSizeAllColumns");
+  autoSizeColumns: () => {
+    console.error("no context provider for autoSizeColumns");
     return null;
   },
   sizeColumnsToFit: () => {

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -407,7 +407,8 @@ export const GridContextProvider = <RowType extends GridBaseRow>(props: GridCont
         return (
           !!(rowNode && nextColumn && nextColDef) &&
           nextColumn.isCellEditable(rowNode) &&
-          !nextColDef.cellEditorParams?.preventAutoEdit
+          !nextColDef.cellEditorParams?.preventAutoEdit &&
+          !nextColDef.cellRendererParams?.editAction
         );
       };
 

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -8,7 +8,7 @@ import { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, u
 
 import { ColDefT, GridBaseRow } from "../components";
 import { isNotEmpty, sanitiseFileName, wait } from "../utils/util";
-import { GridContext, GridFilterExternal } from "./GridContext";
+import { AutoSizeColumnsProps, AutoSizeColumnsResult, GridContext, GridFilterExternal } from "./GridContext";
 import { GridUpdatingContext } from "./GridUpdatingContext";
 
 interface GridContextProps {
@@ -342,12 +342,13 @@ export const GridContextProvider = <RowType extends GridBaseRow>(props: GridCont
   /**
    * Resize columns to fit container
    */
-  const autoSizeAllColumns = useCallback(
-    ({ skipHeader, colIds, userSizedColIds }): { width: number } | null => {
+  const autoSizeColumns = useCallback(
+    ({ skipHeader, colIds, userSizedColIds }: AutoSizeColumnsProps = {}): AutoSizeColumnsResult => {
       if (!columnApi) return null;
+      const colIdsSet = colIds instanceof Set ? colIds : new Set<string>(colIds ?? []);
       columnApi.getColumnState().forEach((col) => {
         const colId = col.colId;
-        if ((!colIds || colIds.includes(colId)) && !userSizedColIds.has(colId)) {
+        if ((isEmpty(colIdsSet) || colIdsSet.has(colId)) && !userSizedColIds?.has(colId)) {
           columnApi.autoSizeColumn(colId, skipHeader);
         }
       });
@@ -617,7 +618,7 @@ export const GridContextProvider = <RowType extends GridBaseRow>(props: GridCont
         ensureRowVisible,
         ensureSelectedRowIsVisible,
         sizeColumnsToFit,
-        autoSizeAllColumns,
+        autoSizeColumns,
         stopEditing,
         cancelEdit,
         updatingCells,

--- a/src/contexts/GridUpdatingContext.tsx
+++ b/src/contexts/GridUpdatingContext.tsx
@@ -2,6 +2,7 @@ import { createContext } from "react";
 
 export type GridUpdatingContextType = {
   checkUpdating: (fields: string | string[], id: number | string) => boolean;
+  isUpdating: () => boolean;
   modifyUpdating: (
     fields: string | string[],
     ids: (number | string)[],
@@ -12,6 +13,10 @@ export type GridUpdatingContextType = {
 
 export const GridUpdatingContext = createContext<GridUpdatingContextType>({
   checkUpdating: () => {
+    console.error("Missing GridUpdatingContext");
+    return false;
+  },
+  isUpdating: () => {
     console.error("Missing GridUpdatingContext");
     return false;
   },

--- a/src/contexts/GridUpdatingContextProvider.tsx
+++ b/src/contexts/GridUpdatingContextProvider.tsx
@@ -1,4 +1,4 @@
-import { castArray, flatten, remove } from "lodash-es";
+import { castArray, flatten, isEmpty, remove } from "lodash-es";
 import { ReactNode, useRef, useState } from "react";
 
 import { GridUpdatingContext } from "./GridUpdatingContext";
@@ -21,11 +21,16 @@ export const GridUpdatingContextProvider = (props: UpdatingContextProviderProps)
   const resetUpdating = () => {
     const mergedUpdatingBlocks: GridUpdatingContextStatus = {};
     for (const key in updatingBlocks.current) {
-      mergedUpdatingBlocks[key] = flatten(updatingBlocks.current[key]);
+      const arr = flatten(updatingBlocks.current[key]);
+      if (arr.length) {
+        mergedUpdatingBlocks[key] = arr;
+      }
     }
     updating.current = mergedUpdatingBlocks;
     setUpdatedDep((updatedDep) => updatedDep + 1);
   };
+
+  const isUpdating = () => !isEmpty(updating.current);
 
   const modifyUpdating = async (
     fields: string | string[],
@@ -50,7 +55,7 @@ export const GridUpdatingContextProvider = (props: UpdatingContextProviderProps)
     castArray(fields).some((f) => updating.current[f]?.includes(id));
 
   return (
-    <GridUpdatingContext.Provider value={{ modifyUpdating, checkUpdating, updatedDep }}>
+    <GridUpdatingContext.Provider value={{ modifyUpdating, checkUpdating, isUpdating, updatedDep }}>
       {props.children}
     </GridUpdatingContext.Provider>
   );

--- a/src/react-menu3/components/MenuList.tsx
+++ b/src/react-menu3/components/MenuList.tsx
@@ -477,7 +477,27 @@ export const MenuList = ({
         top: menuPosition.y,
       }}
     >
-      <div ref={focusRef} tabIndex={-1} style={{ position: "absolute", left: 0, top: 0 }} />
+      <div
+        ref={focusRef}
+        tabIndex={-1}
+        style={{ position: "absolute", left: 0, top: 0 }}
+        onKeyDown={(event) => {
+          if (event.key == "Tab") {
+            event.preventDefault();
+            event.stopPropagation();
+            safeCall(onClose, {
+              key: event.key,
+              shiftKey: event.shiftKey,
+              reason:
+                event.key === "Tab"
+                  ? event.shiftKey
+                    ? CloseReason.TAB_BACKWARD
+                    : CloseReason.TAB_FORWARD
+                  : CloseReason.CLICK,
+            });
+          }
+        }}
+      />
       {arrow && (
         <div
           className={_arrowClass}

--- a/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
+++ b/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
@@ -192,7 +192,7 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
       setRowData([
         ...rowData,
         {
-          id: lastRow.id + 1,
+          id: (lastRow?.id ?? 0) + 1,
           name: "?",
           nameType: "?",
           numba: "?",
@@ -212,6 +212,10 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         columnDefs={columnDefs}
         rowData={rowData}
         domLayout={"autoHeight"}
+        onCellEditingComplete={() => {
+          /* eslint-disable-next-line no-console */
+          console.log("Cell editing complete");
+        }}
       />
       <ActionButton icon={"ic_add"} name={"Add new row"} inProgressName={"Adding..."} onClick={addRowAction} />
     </>

--- a/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
+++ b/src/stories/grid/GridPopoutEditGenericTextArea.stories.tsx
@@ -212,6 +212,8 @@ const GridPopoutEditGenericTemplate: ComponentStory<typeof Grid> = (props: GridP
         columnDefs={columnDefs}
         rowData={rowData}
         domLayout={"autoHeight"}
+        defaultColDef={{ minWidth: 70 }}
+        sizeColumns={"auto"}
         onCellEditingComplete={() => {
           /* eslint-disable-next-line no-console */
           console.log("Cell editing complete");

--- a/src/stories/grid/GridPopoverEditDropDown.stories.tsx
+++ b/src/stories/grid/GridPopoverEditDropDown.stories.tsx
@@ -303,7 +303,10 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
         columnDefs={columnDefs}
         rowData={rowData}
         domLayout={"autoHeight"}
-        onCellEditingComplete={() => console.log("Cell editing complete")}
+        onCellEditingComplete={() => {
+          /* eslint-disable-next-line no-console */
+          console.log("Cell editing complete");
+        }}
       />
     </GridWrapper>
   );

--- a/src/stories/grid/GridPopoverEditDropDown.stories.tsx
+++ b/src/stories/grid/GridPopoverEditDropDown.stories.tsx
@@ -155,6 +155,7 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
         {
           field: "position3",
           headerName: "Filtered",
+          editable: false,
         },
         {
           multiEdit: true,
@@ -302,6 +303,7 @@ const GridEditDropDownTemplate: ComponentStory<typeof Grid> = (props: GridProps)
         columnDefs={columnDefs}
         rowData={rowData}
         domLayout={"autoHeight"}
+        onCellEditingComplete={() => console.log("Cell editing complete")}
       />
     </GridWrapper>
   );

--- a/src/stories/grid/interactions/GridKeyboardInteractions.stories.tsx
+++ b/src/stories/grid/interactions/GridKeyboardInteractions.stories.tsx
@@ -248,7 +248,9 @@ GridKeyboardInteractions.play = async ({ canvasElement }) => {
   await test(() => userEvent.keyboard("{Enter}"), "8", "2");
   await test(() => userEvent.tab(), "9", "2");
   userEvent.tab({ shift: true });
-  await test(() => userEvent.tab({ shift: true }), "7", "2");
+  await test(() => userEvent.tab({ shift: true }), "6", "2");
+  userEvent.keyboard("{Esc}");
+  userEvent.tab();
 
   userEvent.keyboard("{Enter}");
   await wait(250);


### PR DESCRIPTION
* Tab whilst editing edits next/previous field
* Callback for when editing completes
* User sized columns don't resize
* Fixed resize not working when first selected row is scrolled into view
* Fix too many auto size callbacks
* Fix poppedout doesn't auto size
* Auto size changed column after edit
* Fixed when adding the first row to grid resizing doesn't work