### PR TITLE
Pinned columns, deferred resize

### DIFF
--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -352,7 +352,6 @@ export const GridContextProvider = <RowType extends GridBaseRow>(props: GridCont
           columnApi.autoSizeColumn(colId, skipHeader);
         }
       });
-
       return {
         width: sumBy(
           columnApi.getColumnState().filter((col) => !col.hide),
@@ -538,12 +537,12 @@ export const GridContextProvider = <RowType extends GridBaseRow>(props: GridCont
 
   const addExternalFilter = (filter: GridFilterExternal<RowType>) => {
     externalFilters.current.push(filter);
-    onFilterChanged();
+    onFilterChanged().then();
   };
 
   const removeExternalFilter = (filter: GridFilterExternal<RowType>) => {
     remove(externalFilters.current, (v) => v === filter);
-    onFilterChanged();
+    onFilterChanged().then();
   };
 
   const isExternalFilterPresent = (): boolean => externalFilters.current.length > 0;

--- a/src/lui/timeoutHook.tsx
+++ b/src/lui/timeoutHook.tsx
@@ -38,3 +38,16 @@ export const useTimeoutHook = () => {
 
   return invoke;
 };
+
+interface IntervalHookProps {
+  timeoutMs: number;
+  callback: () => void;
+}
+export const useIntervalHook = ({ callback, timeoutMs }: IntervalHookProps) => {
+  useEffect(() => {
+    const interval = setInterval(callback, timeoutMs);
+    return () => {
+      clearInterval(interval);
+    };
+  });
+};


### PR DESCRIPTION
* default grid size is not auto, not auto-ignore-headers
* select column is now default pinned to left.
* grid auto size that happens when grid is not visible is deferred until grid is onscreen
* columns when they become visible are auto sized
