### PR TITLE
SURVEY-17202 adding the ability to place a cell in editing mode

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -83,7 +83,6 @@ export const Grid = ({
   const {
     gridReady,
     setApis,
-    prePopupOps,
     ensureRowVisible,
     getFirstRowId,
     selectRowsById,
@@ -98,7 +97,8 @@ export const Grid = ({
     setOnCellEditingComplete,
     getColDef,
   } = useContext(GridContext);
-  const { checkUpdating, updatedDep, updatingCols } = useContext(GridUpdatingContext);
+  const { updatedDep, updatingCols } = useContext(GridUpdatingContext);
+  const gridContext = useContext(GridContext);
 
   const gridDivRef = useRef<HTMLDivElement>(null);
 
@@ -387,23 +387,13 @@ export const Grid = ({
    */
   const startCellEditing = useCallback(
     (event: CellEvent) => {
-      prePopupOps();
-      if (!event.node.isSelected()) {
-        event.node.setSelected(true, true);
-      }
-      // Cell already being edited, so don't re-edit until finished
-      if (checkUpdating([event.colDef.field ?? ""], event.data.id)) {
-        return;
-      }
-
-      if (event.rowIndex !== null) {
-        event.api.startEditingCell({
-          rowIndex: event.rowIndex,
-          colKey: event.column.getColId(),
+      event.data.id &&
+        gridContext.startCellEditing({
+          rowId: event.data.id,
+          colId: event.column.getColId(),
         });
-      }
     },
-    [checkUpdating, prePopupOps],
+    [gridContext],
   );
 
   /**

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -39,6 +39,7 @@ export interface GridContextType<RowType extends GridBaseRow> {
   autoSizeColumns: (props?: AutoSizeColumnsProps) => AutoSizeColumnsResult;
   sizeColumnsToFit: () => void;
   cancelEdit: () => void;
+  startCellEditing: ({ rowId, colId }: { rowId: number; colId: string }) => void;
   stopEditing: () => void;
   updatingCells: (
     props: { selectedRows: GridBaseRow[]; field?: string },
@@ -146,6 +147,9 @@ export const GridContext = createContext<GridContextType<any>>({
   },
   cancelEdit: () => {
     console.error("no context provider for cancelEdit");
+  },
+  startCellEditing: () => {
+    console.error("no context provider for startCellEditing");
   },
   stopEditing: () => {
     console.error("no context provider for stopEditing");


### PR DESCRIPTION
As part of new functionality in [SURVEY-17202](https://toitutewhenua.atlassian.net/browse/SURVEY-17202), we need the ability to place individual cells into edit mode programmatically. This exposes this functionality on the GridContextProvider.


Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests


[SURVEY-17202]: https://toitutewhenua.atlassian.net/browse/SURVEY-17202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ