### PR TITLE
fix/SURVEY-17202 revert Grid.startCelLEditing back to it's original

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -97,8 +97,8 @@ export const Grid = ({
     setOnCellEditingComplete,
     getColDef,
   } = useContext(GridContext);
-  const { updatedDep, updatingCols } = useContext(GridUpdatingContext);
-  const gridContext = useContext(GridContext);
+  const { checkUpdating, updatedDep, updatingCols } = useContext(GridUpdatingContext);
+  const { prePopupOps } = useContext(GridContext);
 
   const gridDivRef = useRef<HTMLDivElement>(null);
 
@@ -387,13 +387,23 @@ export const Grid = ({
    */
   const startCellEditing = useCallback(
     (event: CellEvent) => {
-      event.data.id &&
-        gridContext.startCellEditing({
-          rowId: event.data.id,
-          colId: event.column.getColId(),
+      prePopupOps();
+      if (!event.node.isSelected()) {
+        event.node.setSelected(true, true);
+      }
+      // Cell already being edited, so don't re-edit until finished
+      if (checkUpdating([event.colDef.field ?? ""], event.data.id)) {
+        return;
+      }
+
+      if (event.rowIndex !== null) {
+        event.api.startEditingCell({
+          rowIndex: event.rowIndex,
+          colKey: event.column.getColId(),
         });
+      }
     },
-    [gridContext],
+    [checkUpdating, prePopupOps],
   );
 
   /**


### PR DESCRIPTION
Reverting Grid.startCellEditing to fix failing front-end tests tests in landonline-survey repo. Quite a few tests over there are coupled to this original implementation