### PR TITLE
Add not zero validation to numbers

### DIFF
--- a/src/utils/textValidator.test.ts
+++ b/src/utils/textValidator.test.ts
@@ -69,6 +69,13 @@ describe("TextInputValidator", () => {
         ],
       },
       {
+        numberFormat: { notZero: true },
+        tests: [
+          ["1", null],
+          ["0", "Must not be 0"],
+        ],
+      },
+      {
         required: true,
         tests: [
           ["xx", null],

--- a/src/utils/textValidator.ts
+++ b/src/utils/textValidator.ts
@@ -13,6 +13,7 @@ export interface TextInputValidatorProps<RowType extends GridBaseRow> {
     geMin?: number;
     ltMax?: number;
     leMax?: number;
+    notZero?: boolean;
   };
 }
 
@@ -44,17 +45,20 @@ export const TextInputValidator = <RowType extends GridBaseRow>(
     }
     if (value != "") {
       const number = parseFloat(value);
+      if (nf.notZero && number === 0) {
+        return `Must not be 0`;
+      }
       if (nf.gtMin != null && number <= nf.gtMin) {
-        return `Must be greater than ${nf.gtMin}`;
+        return `Must be greater than ${nf.gtMin.toLocaleString()}`;
       }
       if (nf.geMin != null && number < nf.geMin) {
-        return `Must not be less than ${nf.geMin}`;
+        return `Must not be less than ${nf.geMin.toLocaleString()}`;
       }
       if (nf.ltMax != null && number >= nf.ltMax) {
-        return `Must be less than ${nf.ltMax}`;
+        return `Must be less than ${nf.ltMax.toLocaleString()}`;
       }
       if (nf.leMax != null && number > nf.leMax) {
-        return `Must not be greater than ${nf.leMax}`;
+        return `Must not be greater than ${nf.leMax.toLocaleString()}`;
       }
 
       if (nf.precision != null && value != "") {

--- a/src/utils/util.test.ts
+++ b/src/utils/util.test.ts
@@ -1,6 +1,17 @@
-import { sanitiseFileName } from "./util";
+import { isFloat, sanitiseFileName } from "./util";
 
 describe("sanitiseFileName", () => {
+  test("isFloat", () => {
+    expect(isFloat("")).toBe(false);
+    expect(isFloat("x")).toBe(false);
+    expect(isFloat("1e10")).toBe(false);
+    expect(isFloat("1x")).toBe(false);
+    expect(isFloat("1.x")).toBe(false);
+    expect(isFloat("x.1")).toBe(false);
+    expect(isFloat("1")).toBe(true);
+    expect(isFloat("1.")).toBe(true);
+    expect(isFloat(".1")).toBe(true);
+  });
   test("sanitiseFileName", () => {
     expect(sanitiseFileName(" LT 1235/543 &%//*$ ")).toBe("LT_1235-543_&%-$");
     expect(sanitiseFileName(" @filename here!!! ")).toBe("@filename_here!!!");

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -11,13 +11,10 @@ export const wait = (timeoutMs: number) =>
 const isFloatRegExp = /^-?\d*\.?\d*$/;
 export const isFloat = (value: string) => {
   try {
-    if (Number.isNaN(parseFloat(value))) {
-      return false;
-    }
-    // Just checking it's not scientific notation here.
+    // Just checking it's not scientific notation or "NaN" here.
     // Also parse float will parse up to the first invalid character,
     // so we need to check there's no remaining invalids e.g. "1.2xyz" would parse as 1.2
-    return isFloatRegExp.test(value);
+    return !Number.isNaN(parseFloat(value)) && isFloatRegExp.test(value);
   } catch {
     return false;
   }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -8,6 +8,8 @@ export const wait = (timeoutMs: number) =>
     setTimeout(resolve, timeoutMs);
   });
 
+// This regexp only works if you parseFloat first, it won't validate a float on its own
+// It prevents scientific 1e10, or trailing decimal 1.2.3, or trailing garbage 1.2xyz
 const isFloatRegExp = /^-?\d*\.?\d*$/;
 export const isFloat = (value: string) => {
   try {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -8,9 +8,19 @@ export const wait = (timeoutMs: number) =>
     setTimeout(resolve, timeoutMs);
   });
 
+const isFloatRegExp = /^-?\d*\.?\d*$/;
 export const isFloat = (value: string) => {
-  const regexp = /^-?\d*(\.\d+)?$/;
-  return regexp.test(value);
+  try {
+    if (Number.isNaN(parseFloat(value))) {
+      return false;
+    }
+    // Just checking it's not scientific notation here.
+    // Also parse float will parse up to the first invalid character,
+    // so we need to check there's no remaining invalids e.g. "1.2xyz" would parse as 1.2
+    return isFloatRegExp.test(value);
+  } catch {
+    return false;
+  }
 };
 
 export const findParentWithClass = function (className: string, child: Node): HTMLElement | null {


### PR DESCRIPTION
* Added notZero to the number format validator.
* Changed number format errors to use .toLocaleString() so we get commas in numbers, e.g. 10,000,000 for 10 million.
* Allow "1." as a valid number so error doesn't occur whilst typing number