### PR TITLE
fix(step-ag-grid): SURVEY-16691: Ensure grid cells get initial size at start

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -121,6 +121,15 @@ export const Grid = ({
       needsAutoSize.current = true;
       return;
     }
+
+    const headerCellCount = gridDivRef.current?.getElementsByClassName("ag-header-cell-label")?.length;
+    if (headerCellCount != params.columnDefs.length) {
+      // Don't resize grids until all the columns are visible
+      // as `autoSizeColumns` will fail silently in this case
+      needsAutoSize.current = true;
+      return;
+    }
+
     const skipHeader = sizeColumns === "auto-skip-headers" && !isEmpty(params.rowData);
     if (sizeColumns === "auto" || skipHeader) {
       const result = autoSizeColumns({ skipHeader, userSizedColIds: userSizedColIds.current });


### PR DESCRIPTION
Story: SURVEY-16691
Task: SURVEY-17749

In some circumstances the cells would not size and would display at the default (with an ellipse if the cell was oversize).

Change here is to not try and resize grids until all the columns are visible as `autoSizeColumns` will fail silently in this case.

Before:
![image](https://github.com/linz/step-ag-grid/assets/575672/87ca0675-ba53-4d60-849c-bab21324df6f)

After:
![image](https://github.com/linz/step-ag-grid/assets/575672/09879a22-f5e2-49aa-9324-114984bfab78)

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [x] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [x] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
