### PR TITLE
fix: SURVEY-18028 clear selections after adding a new row

### DIFF
--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -391,7 +391,7 @@ export const GridContextProvider = <RowType extends GridBaseRow>(props: GridCont
       }
 
       if (!rowNode.isSelected()) {
-        rowNode.setSelected(true, false);
+        rowNode.setSelected(true, true);
       }
 
       // Cell already being edited, so don't re-edit until finished


### PR DESCRIPTION
Story: [SURVEY-18038](https://toitutewhenua.atlassian.net/browse/SURVEY-18028)

Ensure that any previous selections are cleared when you add a new empty row or new purpose. Below animated gif shows it's use in actin.

![SURVEY-18028](https://github.com/linz/step-ag-grid/assets/10938392/5434778b-bbb7-40b5-82b3-368fd6018cc1)

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [x] reasonable code test coverage
- [x] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests


[SURVEY-18038]: https://toitutewhenua.atlassian.net/browse/SURVEY-18038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SURVEY-18028]: https://toitutewhenua.atlassian.net/browse/SURVEY-18028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ