### PR TITLE
Remove sanitize filename due to use of buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "react": ">=17",
         "react-dom": ">=17",
         "react-transition-state": "^2.0.2",
-        "sanitize-filename": "^1.6.3",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -47325,14 +47324,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-      "dependencies": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
     "node_modules/sanitize.css": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
@@ -50529,14 +50520,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
-      "dependencies": {
-        "utf8-byte-length": "^1.0.1"
-      }
-    },
     "node_modules/tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -51357,11 +51340,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/utf8-byte-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
     "node_modules/util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "react": ">=17",
     "react-dom": ">=17",
     "react-transition-state": "^2.0.2",
-    "sanitize-filename": "^1.6.3",
     "uuid": "^9.0.0"
   },
   "scripts": {

--- a/src/utils/util.test.ts
+++ b/src/utils/util.test.ts
@@ -13,7 +13,17 @@ describe("sanitiseFileName", () => {
     expect(isFloat(".1")).toBe(true);
   });
   test("sanitiseFileName", () => {
-    expect(sanitiseFileName(" LT 1235/543 &%//*$ ")).toBe("LT_1235-543_&%-$");
-    expect(sanitiseFileName(" @filename here!!! ")).toBe("@filename_here!!!");
+    expect(sanitiseFileName(" LT 1235/543 &%//*$.csv ")).toBe("LT_1235-543_-.csv");
+    expect(sanitiseFileName(" @filename here!!!.csv ")).toBe("filename_here.csv");
+    // Trim to 64 char max for non extension part
+    expect(sanitiseFileName("long_long_long_long_long_long_long_long_long_long_long_long_long_long_.csv")).toBe(
+      "long_long_long_long_long_long_long_long_long_long_long_long_long.csv",
+    );
+    // Test with no extension
+    expect(sanitiseFileName("long_long_long_long_long_long_long_long_long_long_long_long_long_long_")).toBe(
+      "long_long_long_long_long_long_long_long_long_long_long_long_long",
+    );
+    // Test with no name
+    expect(sanitiseFileName(".csv")).toBe(".csv");
   });
 });

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,5 +1,4 @@
 import { isEmpty, negate } from "lodash-es";
-import sanitize from "sanitize-filename";
 
 export const isNotEmpty = negate(isEmpty);
 
@@ -47,11 +46,15 @@ export const stringByteLengthIsInvalid = (str: string, maxBytes: number) =>
 
 export const fnOrVar = (fn: any, param: any) => (typeof fn === "function" ? fn(param) : fn);
 
-/**
- * Trim filename and replaces troublesome characters.
- *
- * e.g. " LT 1235/543 &%//*$ " => "LT_1235-543_&%-$"
- * e.g. " @filename here!!!" => "@filename_here!!!"
- */
-export const sanitiseFileName = (filename: string): string =>
-  sanitize(filename.trim().replaceAll(/(\/|\\)+/g, "-")).replaceAll(/\s+/g, "_");
+export const sanitiseFileName = (filename: string): string => {
+  const valid = filename
+    .trim()
+    .replaceAll(/(\/|\\)+/g, "-")
+    .replaceAll(/\s+/g, "_")
+    .replaceAll(/[^\w\-āēīōūĀĒĪŌŪ.]/g, "");
+  const parts = valid.split(".");
+  const fileExt = parts.length > 1 ? parts.pop() : undefined;
+  // Arbitrary max filename length of 64 chars + extension
+  if (!fileExt) return valid.slice().slice(0, 64);
+  return valid.slice(0, -fileExt.length - 1).slice(0, 64) + "." + fileExt;
+};


### PR DESCRIPTION
npm librarys for sanitizing filenames are causing too many issues due to use of node libs.
This is our own implemention of sanitize filename.