### PR TITLE
fix: SURVEY-15720 Infer the return type, new RTL returns a promise fo…

### DIFF
--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -213,8 +213,8 @@ export const typeOtherInput = async (value: string): Promise<void> =>
 export const typeOtherTextArea = async (value: string): Promise<void> =>
   typeInput(value, { classes: ".subComponent", child: { tagName: "textarea" } });
 
-export const closeMenu = (): void => userEvent.click(document.body);
-export const closePopover = (): void => userEvent.click(document.body);
+export const closeMenu = () => userEvent.click(document.body);
+export const closePopover = () => userEvent.click(document.body);
 
 export const findActionButton = (text: string, container?: HTMLElement): Promise<HTMLElement> =>
   findQuick({ tagName: "button", child: { classes: ".ActionButton-minimalAreaDisplay", text: text } }, container);


### PR DESCRIPTION
Later versions of RTL `userEvent.click` returns `Promise` This is just to infer the return type for consumers using later version

DESCRIPTION of the task, STORY/TASK number and link if applicable (e.g. SURVEY-100)

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
