### PR TITLE
fix: SYRVEY-15720 Add missing awaits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@testing-library/dom": "^9.3.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.4.3",
         "@trivago/prettier-plugin-sort-imports": "^4.1.1",
         "@types/debounce-promise": "^3.1.6",
         "@types/jest": "^29.5.2",
@@ -15316,6 +15316,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@storybook/testing-library/node_modules/@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@storybook/testing-library/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -16088,31 +16104,16 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
-      }
-    },
-    "node_modules/@testing-library/user-event/node_modules/@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@tippyjs/react": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.4.3",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/debounce-promise": "^3.1.6",
     "@types/jest": "^29.5.2",

--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -31,7 +31,8 @@ const _selectRow = async (
     const isSelected = row.className.includes("ag-row-selected");
     if (select === "toggle" || (select === "select" && !isSelected) || (select === "deselect" && isSelected)) {
       const cell = await findCell(rowId, "selection", within);
-      userEvent.click(cell);
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await userEvent.click(cell);
       await waitFor(async () => {
         const row = await findRow(rowId, within);
         const nowSelected = row.className.includes("ag-row-selected");
@@ -75,14 +76,16 @@ export const findCellContains = async (
 export const selectCell = async (rowId: string | number, colId: string, within?: HTMLElement): Promise<void> => {
   await act(async () => {
     const cell = await findCell(rowId, colId, within);
-    userEvent.click(cell);
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await userEvent.click(cell);
   });
 };
 
 export const editCell = async (rowId: number | string, colId: string, within?: HTMLElement): Promise<void> => {
   await act(async () => {
     const cell = await findCell(rowId, colId, within);
-    userEvent.dblClick(cell);
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await userEvent.dblClick(cell);
   });
   await waitFor(findOpenPopover);
 };
@@ -129,8 +132,8 @@ export const validateMenuOptions = async (
 export const clickMenuOption = async (menuOptionText: string | RegExp): Promise<void> => {
   await act(async () => {
     const menuOption = await findMenuOption(menuOptionText);
-    // eslint-disable-next-line testing-library/await-async-utils
-    userEvent.click(menuOption);
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await userEvent.click(menuOption);
   });
 };
 
@@ -222,6 +225,7 @@ export const findActionButton = (text: string, container?: HTMLElement): Promise
 export const clickActionButton = async (text: string, container?: HTMLElement): Promise<void> => {
   await act(async () => {
     const button = await findActionButton(text, container);
-    userEvent.click(button);
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await userEvent.click(button);
   });
 };

--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -176,17 +176,17 @@ export const findMultiSelectOption = async (value: string): Promise<HTMLElement>
 
 export const clickMultiSelectOption = async (value: string): Promise<void> => {
   const menuItem = await findMultiSelectOption(value);
-  menuItem.parentElement && userEvent.click(menuItem.parentElement);
+  menuItem.parentElement && (await userEvent.click(menuItem.parentElement));
 };
 
 const typeInput = async (value: string, filter: IQueryQuick): Promise<void> =>
   act(async () => {
     const openMenu = await findOpenPopover();
     const input = await findQuick(filter, openMenu);
-    userEvent.clear(input);
-    //'typing' an empty string will cause a console error and it's also unnecessary after the previous clear call
+    await userEvent.clear(input);
+    //'typing' an empty string will cause a console error, and it's also unnecessary after the previous clear call
     if (value.length > 0) {
-      userEvent.type(input, value);
+      await userEvent.type(input, value);
     }
   });
 

--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -31,7 +31,6 @@ const _selectRow = async (
     const isSelected = row.className.includes("ag-row-selected");
     if (select === "toggle" || (select === "select" && !isSelected) || (select === "deselect" && isSelected)) {
       const cell = await findCell(rowId, "selection", within);
-      // eslint-disable-next-line @typescript-eslint/await-thenable
       await userEvent.click(cell);
       await waitFor(async () => {
         const row = await findRow(rowId, within);
@@ -76,7 +75,6 @@ export const findCellContains = async (
 export const selectCell = async (rowId: string | number, colId: string, within?: HTMLElement): Promise<void> => {
   await act(async () => {
     const cell = await findCell(rowId, colId, within);
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await userEvent.click(cell);
   });
 };
@@ -84,7 +82,6 @@ export const selectCell = async (rowId: string | number, colId: string, within?:
 export const editCell = async (rowId: number | string, colId: string, within?: HTMLElement): Promise<void> => {
   await act(async () => {
     const cell = await findCell(rowId, colId, within);
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await userEvent.dblClick(cell);
   });
   await waitFor(findOpenPopover);
@@ -132,7 +129,6 @@ export const validateMenuOptions = async (
 export const clickMenuOption = async (menuOptionText: string | RegExp): Promise<void> => {
   await act(async () => {
     const menuOption = await findMenuOption(menuOptionText);
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await userEvent.click(menuOption);
   });
 };
@@ -225,7 +221,6 @@ export const findActionButton = (text: string, container?: HTMLElement): Promise
 export const clickActionButton = async (text: string, container?: HTMLElement): Promise<void> => {
   await act(async () => {
     const button = await findActionButton(text, container);
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await userEvent.click(button);
   });
 };


### PR DESCRIPTION
## SURVEY-15720

Ads missing `await` to the now async `userEvent.click()`

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
