### PR TITLE
fix: SURVEY-15720 Change to use customised user event

### DIFF
--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -202,8 +202,8 @@ export const typeOtherInput = async (value: string): Promise<void> =>
 export const typeOtherTextArea = async (value: string): Promise<void> =>
   typeInput(value, { classes: ".subComponent", child: { tagName: "textarea" } });
 
-export const closeMenu = () => userEvent.click(document.body);
-export const closePopover = () => userEvent.click(document.body);
+export const closeMenu = () => user.click(document.body);
+export const closePopover = () => user.click(document.body);
 
 export const findActionButton = (text: string, container?: HTMLElement): Promise<HTMLElement> =>
   findQuick({ tagName: "button", child: { classes: ".ActionButton-minimalAreaDisplay", text: text } }, container);


### PR DESCRIPTION
The `closeMenu` and `closePopover` should be using the customised user event so that the await works properly.

Author Checklist

- [x] appropriate description or links provided to provide context on the PR
- [x] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
