### PR TITLE
Deploy

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -7,6 +7,6 @@ module.exports = {
   singleQuote: false,
   endOfLine: "lf",
   importOrder: ["^(.*).(.?)css$", "<THIRD_PARTY_MODULES>", "^@linzjs/(.*)$", "^@step-ag-grid", "^[./]"],
-  importOrderSeparation: true,
   importOrderSortSpecifiers: true,
+  importOrderSeparation: true,
 };


### PR DESCRIPTION
* Upgrade to React18
* Upgrade to grid v29 (v28+ required)
* Node v18+ now required for build
* Auto focus cell on load only focuses if cell is not already focused
* Replaced all JSX.Element with ReactElement 
* Add autoSized as condition for Grid-ready
* Auto size for all rows now calls autoSizeAllColumns instead of iterated over per column
* Wait for first .ag-cell in findRow
* Change default theme to step theme