### PR TITLE
feat: enabled drag/drop moving rows

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -50,7 +50,7 @@ export interface GridProps {
   autoSelectFirstRow?: boolean;
   onColumnMoved?: GridOptions["onColumnMoved"];
   rowDragText?: GridOptions["rowDragText"];
-  onRowDragEnd?: (movedRow: any, targetRow: any) => void;
+  onRowDragEnd?: (movedRow: any, targetRow: any, targetIndex: number) => void;
   alwaysShowVerticalScroll?: boolean;
   suppressColumnVirtualization?: GridOptions["suppressColumnVirtualisation"];
   /**
@@ -331,14 +331,15 @@ export const Grid = ({
             colId: "selection",
             editable: false,
             rowDrag: !!params.onRowDragEnd,
-            minWidth: params.selectable && params.onRowDragEnd ? 72 : 48,
-            maxWidth: params.selectable && params.onRowDragEnd ? 72 : 48,
+            minWidth: params.selectable && params.onRowDragEnd ? 76 : 48,
+            maxWidth: params.selectable && params.onRowDragEnd ? 76 : 48,
             pinned: selectColumnPinned,
             headerComponentParams: {
               exportable: false,
             },
             checkboxSelection: params.selectable,
             headerComponent: rowSelection === "multiple" ? GridHeaderSelect : null,
+            //headerCheckboxSelection:true,
             suppressHeaderKeyboardEvent: (e) => {
               if (!params.selectable) return false;
               if ((e.event.key === "Enter" || e.event.key === " ") && !e.event.repeat) {
@@ -594,7 +595,10 @@ export const Grid = ({
       const moved = event.node.data;
       const target = event.overNode?.data;
 
-      moved.id != target.id && params.onRowDragEnd && params.onRowDragEnd(moved, target);
+      moved.id != target.id &&
+        event.node.rowIndex != null &&
+        params.onRowDragEnd &&
+        params.onRowDragEnd(moved, target, event.node.rowIndex);
     },
     [params],
   );

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -183,8 +183,8 @@ export const Grid = ({
   const lastOwnerDocumentRef = useRef<Document>();
 
   useEffect(() => {
-    setRowData(rowData);
-  }, [rowData, params.rowData]);
+    setRowData(params.rowData);
+  }, [params.rowData]);
   /**
    * Auto-size windows that had deferred auto-size
    */

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -51,7 +51,8 @@ export interface GridProps {
   rowSelection?: "single" | "multiple";
   autoSelectFirstRow?: boolean;
   onColumnMoved?: GridOptions["onColumnMoved"];
-  onRowDragEnd?: (rowToMove: any, index: number) => void;
+  rowDragText?: GridOptions["rowDragText"];
+  onRowDragEnd?: (movedRow: any, targetRow: any) => void;
   alwaysShowVerticalScroll?: boolean;
   suppressColumnVirtualization?: GridOptions["suppressColumnVirtualisation"];
   /**
@@ -629,15 +630,16 @@ export const Grid = ({
 
   const onRowDragEnd = useCallback(
     (event: RowDragEndEvent) => {
-      //index is -1 if the row is dragged off the bottom of the table
-      if (event.overIndex < 0) {
-        setRowData(rowDataBeforeMove);
-        return;
-      }
+      if(rowDataBeforeMove){
+        const moved = event.node.data;
+        const target = rowDataBeforeMove[event.overIndex]
 
-      params.onRowDragEnd && params.onRowDragEnd(event.node.data, event.overIndex);
+        moved.id != target.id
+        && params.onRowDragEnd 
+        && params.onRowDragEnd(moved, target);
+      }
     },
-    [params, rowDataBeforeMove],
+    [params],
   );
 
   // This is setting a ref in the GridContext so won't be triggering an update loop
@@ -658,7 +660,7 @@ export const Grid = ({
         <AgGridReact
           ref={gridRef}
           rowHeight={params.rowHeight}
-          animateRows={params.animateRows}
+          animateRows={params.animateRows}          
           rowClassRules={params.rowClassRules}
           getRowId={(params) => `${params.data.id}`}
           suppressRowClickSelection={true}
@@ -703,6 +705,7 @@ export const Grid = ({
           maintainColumnOrder={true}
           preventDefaultOnContextMenu={true}
           onCellContextMenu={gridContextMenu.cellContextMenu}
+          rowDragText={params.rowDragText}
           onRowDragEnd={onRowDragEnd}
           onRowDragMove={onRowDragMove}
           onRowDragEnter={onRowDragEnter}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -518,6 +518,15 @@ export const Grid = ({
     return columnDefs.map((colDef) => adjustColDefOrGroup(colDef));
   }, [columnDefs, params.defaultColDef?.sortable, sizeColumns]);
 
+  const anyColDefSortable = useMemo(() => {
+    const sortable = params.defaultColDef?.sortable || params.columnDefs.find((c) => c.sortable);
+    if (sortable && params.onRowDragEnd) {
+      console.error("Columns can not be sortable if row dragging is enabled");
+    }
+
+    return sortable;
+  }, [params.defaultColDef, params.columnDefs, params.onRowDragEnd]);
+
   /**
    * Set of colIds that need auto-sizing.
    */
@@ -653,7 +662,7 @@ export const Grid = ({
           onModelUpdated={onModelUpdated}
           onGridReady={onGridReady}
           onSortChanged={ensureSelectedRowIsVisible}
-          postSortRows={params.postSortRows ?? !params.onRowDragEnd ? postSortRows : undefined}
+          postSortRows={anyColDefSortable ? undefined : params.postSortRows ?? postSortRows}
           onSelectionChanged={synchroniseExternalStateToGridSelection}
           onColumnMoved={params.onColumnMoved}
           alwaysShowVerticalScroll={params.alwaysShowVerticalScroll}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -43,7 +43,6 @@ export interface GridProps {
    */
   selectColumnPinned?: ColDef["pinned"];
   noRowsOverlayText?: string;
-  postSortRows?: GridOptions["postSortRows"];
   animateRows?: boolean;
   rowHeight?: number;
   rowClassRules?: GridOptions["rowClassRules"];
@@ -518,15 +517,6 @@ export const Grid = ({
     return columnDefs.map((colDef) => adjustColDefOrGroup(colDef));
   }, [columnDefs, params.defaultColDef?.sortable, sizeColumns]);
 
-  const anyColDefSortable = useMemo(() => {
-    const sortable = params.defaultColDef?.sortable || params.columnDefs.find((c) => c.sortable);
-    if (sortable && params.onRowDragEnd) {
-      console.error("Columns can not be sortable if row dragging is enabled");
-    }
-
-    return sortable;
-  }, [params.defaultColDef, params.columnDefs, params.onRowDragEnd]);
-
   /**
    * Set of colIds that need auto-sizing.
    */
@@ -662,7 +652,7 @@ export const Grid = ({
           onModelUpdated={onModelUpdated}
           onGridReady={onGridReady}
           onSortChanged={ensureSelectedRowIsVisible}
-          postSortRows={anyColDefSortable ? undefined : params.postSortRows ?? postSortRows}
+          postSortRows={params.onRowDragEnd ? undefined : postSortRows}
           onSelectionChanged={synchroniseExternalStateToGridSelection}
           onColumnMoved={params.onColumnMoved}
           alwaysShowVerticalScroll={params.alwaysShowVerticalScroll}

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -1,0 +1,120 @@
+import "../../styles/GridTheme.scss";
+import "../../styles/index.scss";
+import "@linzjs/lui/dist/scss/base.scss";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react/dist/ts3.9/client/preview/types-6-3";
+import { useMemo, useState } from "react";
+
+import "@linzjs/lui/dist/fonts";
+
+import {
+  ColDefT,
+  Grid,
+  GridCell,
+  GridContextProvider,
+  GridProps,
+  GridUpdatingContextProvider,
+  GridWrapper,
+} from "../..";
+import { waitForGridReady } from "../../utils/storybookTestUtil";
+
+export default {
+  title: "Components / Grids",
+  component: Grid,
+  args: {
+    quickFilter: true,
+    quickFilterValue: "",
+    quickFilterPlaceholder: "Quick filter...",
+    selectable: false,
+    rowSelection: "single",
+  },
+  // Storybook hangs otherwise
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 1024, height: 400, display: "flex", flexDirection: "column" }}>
+        <GridUpdatingContextProvider>
+          <GridContextProvider>
+            <Story />
+          </GridContextProvider>
+        </GridUpdatingContextProvider>
+      </div>
+    ),
+  ],
+} as ComponentMeta<typeof Grid>;
+
+interface ITestRow {
+  id: number;
+  position: string;
+  age: number;
+  height: number;
+  desc: string;
+  dd: string;
+}
+
+const GridDragRowTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
+  const columnDefs: ColDefT<ITestRow>[] = useMemo(
+    () => [
+      GridCell({
+        field: "id",
+        headerName: "Id",
+        lockVisible: true,
+      }),
+      GridCell({
+        field: "position",
+        headerName: "Position",
+        cellRendererParams: {
+          warning: (props) => props.value === "Tester" && "Testers are testing",
+          info: (props) => props.value === "Developer" && "Developers are awesome",
+        },
+      }),
+      GridCell({
+        field: "age",
+        headerName: "Age",
+      }),
+      GridCell({
+        field: "height",
+        headerName: "Height",
+      }),
+      GridCell({
+        field: "desc",
+        headerName: "Description",
+        flex: 1,
+      }),
+    ],
+    [],
+  );
+
+  const [rowData] = useState([
+    { id: 1000, position: "Tester", age: 30, height: `6'4"`, desc: "Tests application", dd: "1" },
+    { id: 1001, position: "Developer", age: 12, height: `5'3"`, desc: "Develops application", dd: "2" },
+    { id: 1002, position: "Manager", age: 65, height: `5'9"`, desc: "Manages", dd: "3" },
+  ]);
+
+  return (
+    <GridWrapper maxHeight={300}>
+      <Grid
+        data-testid={"readonly"}
+        {...props}
+        selectable={true}
+        rowSelection="multiple"
+        animateRows={true}
+        columnDefs={columnDefs}
+        defaultColDef={{ sortable: false }}
+        rowData={rowData}
+        onRowDragEnd={(row, index) => {
+          alert(`Row ${row.id} has been moved to index ${index}.`);
+        }}
+      />
+    </GridWrapper>
+  );
+};
+
+export const DragRowSingleSelection = GridDragRowTemplate.bind({});
+DragRowSingleSelection.play = waitForGridReady;

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -108,9 +108,10 @@ const GridDragRowTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
         columnDefs={columnDefs}
         defaultColDef={{ sortable: false }}
         rowData={rowData}
-        onRowDragEnd={(row, index) => {
-          alert(`Row ${row.id} has been moved to index ${index}.`);
+        onRowDragEnd={(row, target) => {
+          alert(`Row ${row.id} has been moved over ${target.id}.`);
         }}
+        rowDragText={(params)=> `${params.rowNode?.data.id} - ${params.rowNode?.data.position}`}
       />
     </GridWrapper>
   );

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -108,8 +108,8 @@ const GridDragRowTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
         columnDefs={columnDefs}
         defaultColDef={{ sortable: false }}
         rowData={rowData}
-        onRowDragEnd={(row, target) => {
-          alert(`Row ${row.id} has been moved over ${target.id}.`);
+        onRowDragEnd={(row, _, targetIndex) => {
+          alert(`Row ${row.id} has been moved to index ${targetIndex}.`);
         }}
         rowDragText={(params) => `${params.rowNode?.data.id} - ${params.rowNode?.data.position}`}
       />

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -1,4 +1,3 @@
-import "../../styles/GridTheme.scss";
 import "../../styles/index.scss";
 import "@linzjs/lui/dist/scss/base.scss";
 
@@ -111,7 +110,7 @@ const GridDragRowTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
         onRowDragEnd={(row, target) => {
           alert(`Row ${row.id} has been moved over ${target.id}.`);
         }}
-        rowDragText={(params)=> `${params.rowNode?.data.id} - ${params.rowNode?.data.position}`}
+        rowDragText={(params) => `${params.rowNode?.data.id} - ${params.rowNode?.data.position}`}
       />
     </GridWrapper>
   );

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -1,3 +1,4 @@
+import "../../styles/GridTheme.scss";
 import "../../styles/index.scss";
 import "@linzjs/lui/dist/scss/base.scss";
 

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -85,10 +85,6 @@
   visibility: visible;
 }
 
-.ag-header-cell-comp-wrapper{
-  justify-content: end;
-}
-
 .ag-drag-handle.ag-row-drag{
   opacity: 0;
 

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -85,6 +85,10 @@
   visibility: visible;
 }
 
+.ag-header-cell-comp-wrapper{
+  justify-content: end;
+}
+
 .GridFormMessage-container {
   padding: 4px 8px;
   max-width: 400px;

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -89,6 +89,24 @@
   justify-content: end;
 }
 
+.ag-drag-handle.ag-row-drag{
+  opacity: 0;
+  .ag-icon-grip{
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='%239999B3' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2Zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2Zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Z' /%3E%3C/svg%3E");
+    background-repeat: no-repeat no-repeat;
+    background-position: center center;
+    background-size: cover;
+    color:transparent;
+  }
+}
+
+.ag-row:hover{
+  .ag-drag-handle.ag-row-drag{
+    opacity: 1;
+    transition: opacity 0.2s ease-in-out;
+  }
+}
+
 .GridFormMessage-container {
   padding: 4px 8px;
   max-width: 400px;

--- a/src/styles/Grid.scss
+++ b/src/styles/Grid.scss
@@ -91,6 +91,7 @@
 
 .ag-drag-handle.ag-row-drag{
   opacity: 0;
+
   .ag-icon-grip{
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='%239999B3' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2Zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2Zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Z' /%3E%3C/svg%3E");
     background-repeat: no-repeat no-repeat;

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -47,9 +47,19 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
   )
 );
 
-// Fix that when you click below checkbox it doesn't process a click
+
 .ag-cell[col-id="selection"] {
-  display: flex;
+  display: flex;// Fix that when you click below checkbox it doesn't process a click
+  justify-content: end; //fix alignment of cell content when grabber is present
+
+  .ag-selection-checkbox{
+    margin-right:0;
+  }
+}
+
+//fix alignment of cell content when grabber is present
+.ag-header-cell-comp-wrapper{
+  justify-content: end;
 }
 
 // Fix that when you click below checkbox it doesn't process a click

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -50,14 +50,14 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
 
 .ag-cell[col-id="selection"] {
   display: flex;// Fix that when you click below checkbox it doesn't process a click
-  justify-content: end; //fix alignment of cell content when grabber is present
+  justify-content: end; // fix alignment of cell content when grabber is present
 
   .ag-selection-checkbox {
     margin-right:0;
   }
 }
 
-//fix alignment of cell content when grabber is present
+// fix alignment of cell content when grabber is present
 .ag-header-cell-comp-wrapper {
   justify-content: end;
 }

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -52,13 +52,13 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
   display: flex;// Fix that when you click below checkbox it doesn't process a click
   justify-content: end; //fix alignment of cell content when grabber is present
 
-  .ag-selection-checkbox{
+  .ag-selection-checkbox {
     margin-right:0;
   }
 }
 
 //fix alignment of cell content when grabber is present
-.ag-header-cell-comp-wrapper{
+.ag-header-cell-comp-wrapper {
   justify-content: end;
 }
 


### PR DESCRIPTION
[SURVEY-18002](https://toitutewhenua.atlassian.net/browse/SURVEY-18002) requires drag/drop row ordering. This PR makes the AG grid drag/drop features accessible to applications.

![CPT2308221555-1700x345](https://github.com/linz/step-ag-grid/assets/109045825/fee10726-9014-41b3-92fb-a5795d35b704)


Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests


[SURVEY-18002]: https://toitutewhenua.atlassian.net/browse/SURVEY-18002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ