### PR TITLE
Remove closeMenuExclusionClassName

### DIFF
--- a/src/components/GridPopoverHook.tsx
+++ b/src/components/GridPopoverHook.tsx
@@ -78,7 +78,6 @@ export const useGridPopoverHook = <RowType extends GridBaseRow>(props: GridPopov
               viewScroll={"auto"}
               dontShrinkIfDirectionIsTop={true}
               className={props.className}
-              closeMenuExclusionClassName={"ReactModal__Content"}
             >
               {saving && ( // This is the overlay that prevents editing when the editor is saving
                 <div className={"ComponentLoadingWrapper-saveOverlay"} />

--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -31,7 +31,6 @@ export const ControlledMenuFr = (
     onItemClick,
     onClose,
     saveButtonRef,
-    closeMenuExclusionClassName,
     ...restProps
   }: ControlledMenuProps & { saveButtonRef?: MutableRefObject<HTMLButtonElement | null> },
   externalRef: ForwardedRef<HTMLUListElement>,
@@ -68,10 +67,8 @@ export const ControlledMenuFr = (
   );
 
   const isWithinMenu = useCallback(
-    (target: EventTarget | null) =>
-      hasParentClass("szh-menu--state-open", target as Node) ||
-      (closeMenuExclusionClassName && hasParentClass(closeMenuExclusionClassName, target as Node)),
-    [closeMenuExclusionClassName],
+    (target: EventTarget | null) => hasParentClass("szh-menu--state-open", target as Node),
+    [],
   );
 
   const handleScreenEventForSave = useCallback(

--- a/src/react-menu3/types.ts
+++ b/src/react-menu3/types.ts
@@ -441,9 +441,4 @@ export interface ControlledMenuProps extends RootMenuProps, ExtraMenuProps {
    * Event fired when menu is about to close.
    */
   onClose?: EventHandler<MenuCloseEvent>;
-
-  /**
-   * When clicking outside the menu to close, anything with this class will not cause a close.
-   */
-  closeMenuExclusionClassName?: string;
 }


### PR DESCRIPTION
It breaks grids within modals

So an issue has popped in in step-ag-grid that if you have a grid inside a LuiModal it won't close/save on clicking outside the dialog.
This was due to some hacked in code to stop the grid popups from closing when a LuiModal OK/Cancel appeared, as the dialog would take focus from the grid.
I'm going to remove this code as there's an alternate way of doing this, specifically in your onSave handler you should return a promise if it's going to show a dialog, and resolve the promise when the dialog is approved.