### PR TITLE
Fix modal dialog issues

### DIFF
--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -67,7 +67,11 @@ export const ControlledMenuFr = (
   );
 
   const isWithinMenu = useCallback(
-    (target: EventTarget | null) => hasParentClass("szh-menu--state-open", target as Node),
+    (target: EventTarget | null) =>
+      hasParentClass("szh-menu--state-open", target as Node) ||
+      // This is temporary, it will be removed when the overlay click is fixed
+      hasParentClass("LuiModalPrefab", target as Node) ||
+      hasParentClass("prefab-modal", target as Node),
     [],
   );
 


### PR DESCRIPTION
When modal dialogs show, on user interaction, the underlying popups close.
This is a temporary fix, await react-menu rewrite.
