### PR TITLE
fix: select column checkbox now centered correctly in row and header

### DIFF
--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -50,11 +50,6 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
 
 .ag-cell[col-id="selection"] {
   display: flex;// Fix that when you click below checkbox it doesn't process a click
-  justify-content: end; // fix alignment of cell content when grabber is present
-
-  .ag-selection-checkbox {
-    margin-right:0;
-  }
 }
 
 // fix alignment of cell content when grabber is present
@@ -92,6 +87,7 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
 
 .ag-header .ag-header-cell[aria-colindex="1"] {
   padding-left: 17px;
+  padding-right: 15px;
 }
 
 .ag-cell[role="gridcell"] {


### PR DESCRIPTION
Centering of selection checkbox was altered by row drag feature PR. This PR reverts some of the CSS changes for that feature and adds padding to the header checkbox so that it lines up when the row grabber is present.

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
