### PR TITLE
fix: row drag moving row prematurely

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -613,23 +613,23 @@ export const Grid = ({
     (event: RowDragEndEvent) => {
       const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
 
-      if (event.overNode) {
+      if (event.node.rowIndex) {
         const lastHighlightedRowNode = clientSideRowModel.getLastHighlightedRowNode();
         const isBelow = lastHighlightedRowNode && lastHighlightedRowNode.highlighted === RowHighlightPosition.Below;
 
-        const moved = event.node;
-        const target = event.overNode;
         let targetIndex = event.overIndex;
-        if (moved.rowIndex! > event.overIndex) {
+        if (event.node.rowIndex > event.overIndex) {
           targetIndex += isBelow ? 1 : 0;
         } else {
           targetIndex += isBelow ? 0 : -1;
         }
 
-        moved.data.id != target.data.id &&
+        const moved = event.node.data;
+        const target = event.overNode?.data;
+        moved.id != target.id &&
           moved.rowIndex != targetIndex &&
           params.onRowDragEnd &&
-          params.onRowDragEnd(moved.data, target.data, targetIndex);
+          params.onRowDragEnd(moved, target, targetIndex);
       }
       clientSideRowModel.highlightRowAtPixel(null);
     },

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -611,9 +611,8 @@ export const Grid = ({
 
   const onRowDragEnd = useCallback(
     (event: RowDragEndEvent) => {
-      const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
-
       if (event.node.rowIndex) {
+        const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
         const lastHighlightedRowNode = clientSideRowModel.getLastHighlightedRowNode();
         const isBelow = lastHighlightedRowNode && lastHighlightedRowNode.highlighted === RowHighlightPosition.Below;
 
@@ -626,12 +625,11 @@ export const Grid = ({
 
         const moved = event.node.data;
         const target = event.overNode?.data;
-        moved.id != target.id &&
-          moved.rowIndex != targetIndex &&
+        moved.id != target.id && //moved over a different row
+          moved.rowIndex != targetIndex && //moved to a different index
           params.onRowDragEnd &&
           params.onRowDragEnd(moved, target, targetIndex);
       }
-      clientSideRowModel.highlightRowAtPixel(null);
     },
     [params],
   );

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -5,7 +5,7 @@ import {
   ColumnResizedEvent,
   IClientSideRowModel,
   ModelUpdatedEvent,
-  RowHighlightPosition, //RowHighlightPosition,
+  RowHighlightPosition,
   RowNode,
 } from "ag-grid-community";
 import { CellClassParams, EditableCallback, EditableCallbackParams } from "ag-grid-community/dist/lib/entities/colDef";

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -60,7 +60,7 @@ export interface GridProps {
   autoSelectFirstRow?: boolean;
   onColumnMoved?: GridOptions["onColumnMoved"];
   rowDragText?: GridOptions["rowDragText"];
-  onRowDragEnd?: (movedRow: any, targetRow: any, targetIndex: number) => void;
+  onRowDragEnd?: (movedRow: any, targetRow: any, targetIndex: number) => Promise<void>;
   alwaysShowVerticalScroll?: boolean;
   suppressColumnVirtualization?: GridOptions["suppressColumnVirtualisation"];
   /**
@@ -610,9 +610,9 @@ export const Grid = ({
   }, []);
 
   const onRowDragEnd = useCallback(
-    (event: RowDragEndEvent) => {
+    async (event: RowDragEndEvent) => {
+      const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
       if (event.node.rowIndex) {
-        const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
         const lastHighlightedRowNode = clientSideRowModel.getLastHighlightedRowNode();
         const isBelow = lastHighlightedRowNode && lastHighlightedRowNode.highlighted === RowHighlightPosition.Below;
 
@@ -628,8 +628,9 @@ export const Grid = ({
         moved.id != target.id && //moved over a different row
           moved.rowIndex != targetIndex && //moved to a different index
           params.onRowDragEnd &&
-          params.onRowDragEnd(moved, target, targetIndex);
+          (await params.onRowDragEnd(moved, target, targetIndex));
       }
+      clientSideRowModel.highlightRowAtPixel(null);
     },
     [params],
   );

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -95,6 +95,7 @@ const GridDragRowTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
     { id: 1000, position: "Tester", age: 30, height: `6'4"`, desc: "Tests application", dd: "1" },
     { id: 1001, position: "Developer", age: 12, height: `5'3"`, desc: "Develops application", dd: "2" },
     { id: 1002, position: "Manager", age: 65, height: `5'9"`, desc: "Manages", dd: "3" },
+    { id: 1003, position: "BA", age: 42, height: `5'7"`, desc: "BAs", dd: "4" },
   ]);
 
   return (

--- a/src/stories/grid/GridDragRow.stories.tsx
+++ b/src/stories/grid/GridDragRow.stories.tsx
@@ -109,7 +109,7 @@ const GridDragRowTemplate: ComponentStory<typeof Grid> = (props: GridProps) => {
         defaultColDef={{ sortable: false }}
         rowData={rowData}
         onRowDragEnd={(row, _, targetIndex) => {
-          alert(`Row ${row.id} has been moved to index ${targetIndex}.`);
+          alert(`Row ${row.id} request to be moved to index ${targetIndex}.`);
         }}
         rowDragText={(params) => `${params.rowNode?.data.id} - ${params.rowNode?.data.position}`}
       />

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -50,11 +50,6 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
 
 .ag-cell[col-id="selection"] {
   display: flex;// Fix that when you click below checkbox it doesn't process a click
-  justify-content: end; // fix alignment of cell content when grabber is present
-
-  .ag-selection-checkbox {
-    margin-right:0;
-  }
 }
 
 // fix alignment of cell content when grabber is present
@@ -92,6 +87,7 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
 
 .ag-header .ag-header-cell[aria-colindex="1"] {
   padding-left: 17px;
+  padding-right: 15px;
 }
 
 .ag-cell[role="gridcell"] {


### PR DESCRIPTION
Managed row dragging in AG Grid moves the row before the onRowDragEnd is fired. This works fine is most scenarios but when needing to cancel from a dialog that pops up on edit, undoing that move was proving to be difficult. This PR switches the row dragging to unmanaged and adds some handlers for the drag events calling the same methods for highlighting the row on move/leave and calculating the target index on drag end.

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
