### PR TITLE
fix: made row drag highlight more visible

### DIFF
--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -194,4 +194,18 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
   .ag-cell-wrapper {
     width: 100%;
   }
+
+  .ag-row-highlight-above::after, .ag-row-highlight-below::after {
+    content: '';
+    height: 2px;
+    background-color: transparent;
+  }
+  
+  .ag-row-highlight-above::after{
+    border-top: 2px dashed lui.$andrea;
+  
+  }
+  .ag-row-highlight-below::after {
+    border-bottom: 2px dashed lui.$andrea;
+  }
 }


### PR DESCRIPTION
This PR makes the drag placement highlight for row dragging more visible and use a lui colour. Based on feedback from Andi.

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
