### PR TITLE
fix: made row drag highlight less 'jittery' and only show when it would result in a change

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -611,8 +611,19 @@ export const Grid = ({
   }, []);
 
   const onRowDragMove = useCallback((event: RowDragMoveEvent) => {
-    const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
-    clientSideRowModel.highlightRowAtPixel(event.node as RowNode<any>, event.y);
+    if (event.overNode && event.node.rowIndex != null) {
+      const clientSideRowModel = event.api.getModel() as IClientSideRowModel;
+
+      //position 0 means highlight above, 1 means below
+      const position = clientSideRowModel.getHighlightPosition(event.y, event.overNode as RowNode<any>);
+
+      //we don't want to show the row highlight if it wouldn't result in the row moving
+      const targetIndex = event.overIndex + position - (event.node.rowIndex < event.overIndex ? 1 : 0);
+      //console.log(targetIndex)
+      if (event.node.rowIndex != targetIndex) {
+        clientSideRowModel.highlightRowAtPixel(event.node as RowNode<any>, event.y);
+      }
+    }
   }, []);
 
   const onRowDragEnd = useCallback(

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -202,12 +202,12 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
   }
   
   .ag-row-highlight-above::after {
-    top:-3px; //moves the top highlight to the position of the bottom highlight
+    top:-3px; // moves the top highlight to the position of the bottom highlight
     border-top: 2px dashed lui.$andrea;
   }
 
   .ag-row-highlight-above:first-of-type:after {
-    top:0px; //the first row highlight needs to in the normal position otherwise it is cut off by the top of the table
+    top:0px; // the first row highlight needs to in the normal position otherwise it is cut off by the top of the table
   }
 
   .ag-row-highlight-below::after {

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -202,9 +202,14 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
   }
   
   .ag-row-highlight-above::after{
+    top:-3px; //moves the top highlight to the position of the bottom highlight
     border-top: 2px dashed lui.$andrea;
-  
   }
+
+  .ag-row-highlight-above:first-of-type:after{
+    top:0px; //the first row highlight needs to in the normal position otherwise it is cut off by the top of the table
+  }
+
   .ag-row-highlight-below::after {
     border-bottom: 2px dashed lui.$andrea;
   }

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -194,4 +194,18 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
   .ag-cell-wrapper {
     width: 100%;
   }
+
+  .ag-row-highlight-above::after, .ag-row-highlight-below::after {
+    content: '';
+    height: 2px;
+    background-color: transparent;
+  }
+  
+  .ag-row-highlight-above::after{
+    border-top: 2px dashed lui.$andrea;
+  
+  }
+  .ag-row-highlight-below::after {
+    border-bottom: 2px dashed lui.$andrea;
+  }
 }

--- a/src/styles/GridTheme.scss
+++ b/src/styles/GridTheme.scss
@@ -201,12 +201,12 @@ $grid-base-font-size: calc(#{lui.$base-font-size} - 1px);
     background-color: transparent;
   }
   
-  .ag-row-highlight-above::after{
+  .ag-row-highlight-above::after {
     top:-3px; //moves the top highlight to the position of the bottom highlight
     border-top: 2px dashed lui.$andrea;
   }
 
-  .ag-row-highlight-above:first-of-type:after{
+  .ag-row-highlight-above:first-of-type:after {
     top:0px; //the first row highlight needs to in the normal position otherwise it is cut off by the top of the table
   }
 


### PR DESCRIPTION
Fixes a couple of minor row drag issues
* Tweaks the css so that the top and bottom row highlights display in the same place so it doesn't 'jitter' when moving between two rows
* Do not show the row highlight if the current target index would result in no move occurring

Author Checklist

- [X] appropriate description or links provided to provide context on the PR
- [X] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
