### PR TITLE
chore: reexport test utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,37 @@ export * from "./react-menu3/types";
 export * from "./utils/bearing";
 export * from "./utils/util";
 export * from "./utils/deferredPromise";
+export {
+  clickActionButton,
+  clickMenuOption,
+  clickMultiSelectOption,
+  closeMenu,
+  closePopover,
+  countRows,
+  deselectRow,
+  editCell,
+  findActionButton,
+  findCell,
+  findCellContains,
+  findMenuOption,
+  findMultiSelectOption,
+  findOpenPopover,
+  findRow,
+  getMultiSelectOptions,
+  isCellReadOnly,
+  openAndClickMenuOption,
+  openAndFindMenuOption,
+  queryMenuOption,
+  queryRow,
+  selectCell,
+  selectRow,
+  setUpUserEvent,
+  typeInputByLabel,
+  typeInputByPlaceholder,
+  typeOnlyInput,
+  typeOtherInput,
+  typeOtherTextArea,
+  validateMenuOptions,
+  waitForGridReady,
+  waitForGridRows
+} from "./utils/testUtil";

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,36 +20,6 @@ export * from "./utils/bearing";
 export * from "./utils/util";
 export * from "./utils/deferredPromise";
 export {
-  clickActionButton,
-  clickMenuOption,
-  clickMultiSelectOption,
-  closeMenu,
-  closePopover,
   countRows,
-  deselectRow,
-  editCell,
-  findActionButton,
-  findCell,
-  findCellContains,
-  findMenuOption,
-  findMultiSelectOption,
-  findOpenPopover,
-  findRow,
-  getMultiSelectOptions,
-  isCellReadOnly,
-  openAndClickMenuOption,
-  openAndFindMenuOption,
-  queryMenuOption,
-  queryRow,
-  selectCell,
-  selectRow,
-  setUpUserEvent,
-  typeInputByLabel,
-  typeInputByPlaceholder,
-  typeOnlyInput,
-  typeOtherInput,
-  typeOtherTextArea,
-  validateMenuOptions,
-  waitForGridReady,
-  waitForGridRows
+  queryRow
 } from "./utils/testUtil";


### PR DESCRIPTION
Re export test utilities in a different way

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
