### PR TITLE
BREAKING_CHANGE: stop events propagation on escape, escape handled on keyup not keydown

### DIFF
--- a/src/react-menu3/components/ControlledMenu.tsx
+++ b/src/react-menu3/components/ControlledMenu.tsx
@@ -264,10 +264,12 @@ export const ControlledMenuFr = (
     [onItemClick, onClose],
   );
 
-  const onKeyDown = ({ key }: KeyboardEvent) => {
-    switch (key) {
+  const onKeyUp = (e: KeyboardEvent) => {
+    switch (e.key) {
       case Keys.ESC:
-        safeCall(onClose, { key, reason: CloseReason.CANCEL });
+        e.preventDefault();
+        e.stopPropagation();
+        safeCall(onClose, { key: e.key, reason: CloseReason.CANCEL });
         break;
     }
   };
@@ -298,7 +300,7 @@ export const ControlledMenuFr = (
 
   const menuList = (
     <div
-      {...mergeProps({ onKeyDown, onBlur }, containerProps)}
+      {...mergeProps({ onKeyUp, onBlur }, containerProps)}
       className={useBEM({
         block: menuContainerClass,
         modifiers,


### PR DESCRIPTION
When pressing escape in survey capture the key event handler doesn't stop propagation thus escape key also deselects everything on the map as well as closing the popup.
* escape handled on keyup, not keydown
* keyup event uses stop propogation/prevent default

This is listed as breaking change just in case people are expecting keydown to be blocked.