### PR TITLE
FIX: Use getQuick for the regexp test otherwise it could timeout erroneously

### DIFF
--- a/src/utils/testUtil.ts
+++ b/src/utils/testUtil.ts
@@ -133,7 +133,7 @@ export const findCellContains = async (
   return await waitFor(
     async () => {
       const row = await findRow(rowId, within);
-      return await findQuick({ tagName: `[col-id='${colId}']`, text }, row);
+      return getQuick({ tagName: `[col-id='${colId}']`, text }, row);
     },
     { timeout: 10000 },
   );


### PR DESCRIPTION
Use getQuick for the regexp test otherwise it could timeout erroneously