### PR TITLE
fix: custom filter loses focus after filter

### DIFF
--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -641,11 +641,11 @@ export const GridContextProvider = <TData extends GridBaseRow>(props: PropsWithC
       debounce(() => {
         // This is terrible, but there's no other way for me to check whether a filter has changed the grid
         const getDisplayedRowsHash = () => {
-          let hash = "";
+          const arr: any[] = [];
           gridApi?.forEachNodeAfterFilter((rowNode) => {
-            hash += String(rowNode.id);
+            arr.push(rowNode.id);
           });
-          return hash;
+          return arr.join("|");
         };
 
         if (gridApi) {

--- a/src/stories/grid/GridReadOnly.stories.tsx
+++ b/src/stories/grid/GridReadOnly.stories.tsx
@@ -255,7 +255,14 @@ const GridReadOnlyTemplate: StoryFn<typeof Grid> = (props: GridProps) => {
   );
 };
 
-const GridFilterLessThan = (props: { field: keyof ITestRow; text: string }): ReactElement => {
+type KeysOfType<TObject, TValue> = {
+  [K in keyof TObject]: TObject[K] extends TValue ? K : never;
+}[keyof TObject];
+
+const GridFilterLessThan = (props: {
+  field: KeysOfType<ITestRow, number | null | undefined>;
+  text: string;
+}): ReactElement => {
   const [value, setValue] = useState<number>();
 
   const filter = useCallback(


### PR DESCRIPTION
Ag-grid has a bug where if a focused cell comes into view after a filter the filter loses focus.
To prevent this I clear the focus after filter