### PR TITLE
feat: SRVTRI-3123 Apply sort on added item

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -131,6 +131,7 @@ export const Grid = ({
     setApis,
     ensureRowVisible,
     getFirstRowId,
+    resetColumnSortState,
     selectRowsById,
     focusByRowById,
     ensureSelectedRowIsVisible,
@@ -425,6 +426,8 @@ export const Grid = ({
       previousRowDataLength.current = length;
     }
 
+    defer(resetColumnSortState);
+
     if (lastUpdatedDep.current === updatedDep || isEmpty(colIdsEdited.current)) return;
     lastUpdatedDep.current = updatedDep;
 
@@ -436,7 +439,15 @@ export const Grid = ({
       autoSizeColumns({ skipHeader, userSizedColIds: userSizedColIds.current, colIds: colIdsEdited.current });
     }
     colIdsEdited.current.clear();
-  }, [autoSizeColumns, rowData?.length, setInitialContentSize, sizeColumns, updatedDep, updatingCols]);
+  }, [
+    autoSizeColumns,
+    resetColumnSortState,
+    rowData?.length,
+    setInitialContentSize,
+    sizeColumns,
+    updatedDep,
+    updatingCols,
+  ]);
 
   /**
    * Show/hide no rows overlay when model changes.

--- a/src/contexts/GridContext.tsx
+++ b/src/contexts/GridContext.tsx
@@ -32,6 +32,7 @@ export interface GridContextType<TData extends GridBaseRow> {
   getFilteredSelectedRows: <T extends GridBaseRow>() => T[];
   getSelectedRowIds: () => number[];
   getFilteredSelectedRowIds: () => number[];
+  resetColumnSortState: () => void;
   selectRowsDiff: (updateFn: () => Promise<any>) => Promise<void>;
   selectRowsWithFlashDiff: (updateFn: () => Promise<any>) => Promise<void>;
   selectRowsById: (rowIds?: number[]) => void;
@@ -118,6 +119,9 @@ export const GridContext = createContext<GridContextType<any>>({
   getFilteredSelectedRowIds: () => {
     console.error("no context provider for getFilteredSelectedRowIds");
     return [];
+  },
+  resetColumnSortState: () => {
+    console.error("no context provider for resetColumnSortState");
   },
   selectRowsDiff: async () => {
     console.error("no context provider for selectRowsDiff");

--- a/src/contexts/GridContextProvider.tsx
+++ b/src/contexts/GridContextProvider.tsx
@@ -329,6 +329,12 @@ export const GridContextProvider = <TData extends GridBaseRow>(props: PropsWithC
     [_selectRowsWithOptionalFlash],
   );
 
+  const resetColumnSortState = useCallback(() => {
+    gridApi?.applyColumnState({
+      defaultState: { sort: null },
+    });
+  }, [gridApi]);
+
   const selectRowsDiff = useCallback(
     async (fn: () => Promise<any>) => {
       beforeUpdate();
@@ -748,6 +754,7 @@ export const GridContextProvider = <TData extends GridBaseRow>(props: PropsWithC
         gridReady,
         prePopupOps,
         postPopupOps,
+        resetColumnSortState,
         setApis,
         setQuickFilter,
         selectRowsById,


### PR DESCRIPTION
We have a requirement to always honour the sort settings whenever adding new rows.
Current ag-grid seems to be very smart and always add the latest new row at the bottom. 

### Current Behavior 
![grid-sort](https://github.com/user-attachments/assets/861a77fa-ecf4-41b7-b36d-94208e5d3a8d)

### Proposed Behavior 
![grid-sort-new](https://github.com/user-attachments/assets/1cd3d4ef-3965-45c1-8b02-a9924f8f60b2)

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
