### PR TITLE
chore: auto update Github actions except for unverified ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
This pull request is opened automatically by [linz/security-gha-scan](https://github.com/linz/security-gha-scan) to ensure that the usage of Github Actions meets [LINZ security requirements](https://toitutewhenua.atlassian.net/wiki/x/h5SRHQ).

Please review and merge it as soon as possible, contact [#team-step-security](https://linz.enterprise.slack.com/archives/C03278T3HCK) or [#team-step-enablement](https://linz.enterprise.slack.com/archives/CMP0BQ2V7) if you have any question.
