### PR TITLE
feat: add ag-disabled css conditional class to GridEditBoolean

### DIFF
--- a/src/components/gridPopoverEdit/GridEditBoolean.tsx
+++ b/src/components/gridPopoverEdit/GridEditBoolean.tsx
@@ -24,12 +24,19 @@ const BooleanCellRenderer = (props: CustomCellEditorProps) => {
     };
   }, [api, column, node.rowIndex]);
 
+  const isDisabled = !fnOrVar(colDef?.editable, props);
+
   return (
-    <div className={clsx("ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper", { "ag-checked": props.value })}>
+    <div
+      className={clsx("ag-wrapper ag-input-wrapper ag-checkbox-input-wrapper", {
+        "ag-checked": props.value,
+        "ag-disabled": isDisabled,
+      })}
+    >
       <input
         type="checkbox"
         className="ag-input-field-input ag-checkbox-input"
-        disabled={!fnOrVar(colDef?.editable, props)}
+        disabled={isDisabled}
         ref={inputRef}
         checked={value}
         onChange={() => {}}


### PR DESCRIPTION
A simple update that inserts a new conditional css class in the `GridEditBoolean` Component when the child input is in a disabled state.

Required for overriding styles on inputs that are disabled in story [SRVPUW-1063](https://toitutewhenua.atlassian.net/browse/SRVPUW-1063)

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests


[SRVPUW-1063]: https://toitutewhenua.atlassian.net/browse/SRVPUW-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ