### PR TITLE
feat: SURVEY-25913 text input format error

### DIFF
--- a/src/lui/FormError.scss
+++ b/src/lui/FormError.scss
@@ -1,7 +1,25 @@
 @use "../../node_modules/@linzjs/lui/dist/scss/Foundation/Variables/ColorVars" as colors;
 
-.FormError-helpText {
-  font-size: 0.75rem;
-  color: colors.$fuscous;
-  font-weight: 400;
+
+.FormError {
+  display: flex;
+
+  &-helpText {
+    font-size: 0.75rem;
+    color: colors.$fuscous;
+    font-weight: 400;
+  }
+
+  &-text-icon {
+    margin-top: 4px;
+    margin-right: 4px;
+  }
+
+  &-error {
+    padding-left: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: colors.$charcoal;
+    align-items: center;
+  }
 }

--- a/src/lui/FormError.tsx
+++ b/src/lui/FormError.tsx
@@ -1,6 +1,7 @@
 import "./FormError.scss";
 
 import { ReactElement } from "react";
+import { LuiIcon } from "@linzjs/lui";
 
 export interface FormErrorProps {
   helpText?: string;
@@ -11,9 +12,10 @@ export const FormError = (props: FormErrorProps) => {
   return (
     <>
       {props.error && (
-        <span className="LuiTextInput-error" style={{ paddingLeft: 0 }}>
-          {props.error}
-        </span>
+        <div className="FormError">
+          <LuiIcon alt="error" name="ic_error" className="FormError-text-icon" size="sm" status="error" />
+          <span className="FormError-error">{props.error}</span>
+        </div>
       )}
 
       {props.helpText && !props.error && <span className={"FormError-helpText"}>{props.helpText}</span>}

--- a/src/lui/TextInputFormatted.scss
+++ b/src/lui/TextInputFormatted.scss
@@ -1,3 +1,5 @@
+@use "@linzjs/lui/dist/scss/Core" as lui;
+
 .LuiTextInput.GridLuiTextInput {
   margin-bottom: 0;
 }
@@ -7,5 +9,5 @@
   right: 14px;
   top: 0;
   line-height: 48px;
-  color: #beb9b4;
+  color: lui.$fuscous;
 }


### PR DESCRIPTION
As Andi's require:

- change format text to fuscous
- include error icon on error
- change error text colour to charcoal
- 
![image](https://github.com/user-attachments/assets/fa35fefb-1e26-456b-83b1-8cdc606d9bf4)

Author Checklist

- [ ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
