### PR TITLE
fix: clickInputWhenContainingCellClicked doesn't work if row selection is on

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -750,7 +750,10 @@ export const Grid = <TData extends GridBaseRow = GridBaseRow>({
               }
               return false;
             },
-            onCellClicked: clickInputWhenContainingCellClicked,
+            onCellClicked:
+              params.enableSelectionWithoutKeys || params.enableClickSelection
+                ? undefined
+                : clickInputWhenContainingCellClicked,
           }}
         />
       </div>

--- a/src/components/clickInputWhenContainingCellClicked.tsx
+++ b/src/components/clickInputWhenContainingCellClicked.tsx
@@ -28,9 +28,11 @@ export const clickInputWhenContainingCellClicked = (params: CellClickedEvent) =>
     if (!cell) return;
 
     const input = cell.querySelector('input, button');
-    if (!input) return;
+    if (!input) {
+      return;
+    }
 
-    input?.dispatchEvent(event);
+    input.dispatchEvent(event);
   };
 
   setTimeout(clickInput, 20);


### PR DESCRIPTION
fix: clickInputWhenContainingCellClicked doesn't work if row selection is on

the click conflicts with the row selection click handler