### PR TITLE
feat: Filter is exact match unless separated by commas

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -756,11 +756,8 @@ export const Grid = <TData extends GridBaseRow = GridBaseRow>({
             );
           }}
           quickFilterParser={(filterStr) => {
-            filterStr = filterStr.trim();
-            const quoted = filterStr.startsWith('"');
-            filterStr = filterStr.replace(/^"/, '').replace(/"$/, '');
-            // If the user encloses the search term in quotes, treat it as an exact match otherwise split by space
-            return quoted ? [filterStr] : filterStr.split(' ');
+            // filter is exact matches exactly groups separated by commas
+            return filterStr.split(',').map((str) => str.trim());
           }}
           onModelUpdated={onModelUpdated}
           onGridReady={onGridReady}


### PR DESCRIPTION
Filter is exact match unless separated by commas.
So:
"abc,xyz" will filter for "abc" and "xyz"
"abc xyz" will filter for "abc xyz"
