### PR TITLE
Feat/add row clicked

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -15,10 +15,11 @@ import {
   GridReadyEvent,
   ModelUpdatedEvent,
   ModuleRegistry,
+  RowClickedEvent,
+  RowDoubleClickedEvent,
   RowDragEndEvent,
   RowDragMoveEvent,
   SelectionChangedEvent,
-  RowClickedEvent, RowDoubleClickedEvent,
 } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import clsx from 'clsx';

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -18,6 +18,7 @@ import {
   RowDragEndEvent,
   RowDragMoveEvent,
   SelectionChangedEvent,
+  RowClickedEvent, RowDoubleClickedEvent,
 } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import clsx from 'clsx';
@@ -147,6 +148,8 @@ export interface GridProps<TData extends GridBaseRow = GridBaseRow> {
   suppressCellFocus?: boolean;
   pinnedTopRowData?: GridOptions['pinnedTopRowData'];
   pinnedBottomRowData?: GridOptions['pinnedBottomRowData'];
+  onRowClicked?: (event: RowClickedEvent) => void;
+  onRowDoubleClicked?: (event: RowDoubleClickedEvent) => void;
 }
 
 /**
@@ -809,6 +812,8 @@ export const Grid = <TData extends GridBaseRow = GridBaseRow>({
                 ? undefined
                 : clickInputWhenContainingCellClicked,
           }}
+          onRowClicked={params.onRowClicked}
+          onRowDoubleClicked={params.onRowDoubleClicked}
         />
       </div>
     </div>


### PR DESCRIPTION

This pull request adds support for handling row click and double-click events in the `Grid` component. The main changes introduce new event props and ensure they are passed to the underlying grid implementation.

**Event Handling Enhancements:**

* Added `onRowClicked` and `onRowDoubleClicked` props to the `GridProps` interface, allowing consumers of the `Grid` component to provide handlers for row click and double-click events.
* Imported `RowClickedEvent` and `RowDoubleClickedEvent` from `ag-grid-community` to support the new event handlers.
* Passed the new `onRowClicked` and `onRowDoubleClicked` props through to the `AgGridReact` component so that event handlers are properly wired up.

Author Checklist

- [X ] appropriate description or links provided to provide context on the PR
- [ ] self reviewed, seems easy to understand and follow
- [ ] reasonable code test coverage
- [ ] change is documented in Storybook and/or markdown files

Reviewer Checklist

- Follows convention
- Does what the author says it will do
- Does not appear to cause side effects and breaking changes
  - if it does cause breaking changes, those are appropriately referenced

Post merge

- [ ] Post about the change in #lui-cop

Conventional Commit Cheat Sheet:
**build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
**ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
**docs**: Documentation only changes
**feat**: A new feature
**fix**: A bug fix
**perf**: A code change that improves performance
**refactor**: A code change that neither fixes a bug nor adds a feature
**test**: Adding missing tests or correcting existing tests
